### PR TITLE
Improvements Phase 2

### DIFF
--- a/BccCode.Linq.sln.DotSettings
+++ b/BccCode.Linq.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Includable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/BccCode.Linq/Async/AsyncEnumerable.cs
+++ b/src/BccCode.Linq/Async/AsyncEnumerable.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace BccCode.Linq.Async;
 
 /// <summary>
@@ -5,6 +7,13 @@ namespace BccCode.Linq.Async;
 /// </summary>
 internal static class AsyncEnumerable
 {
+    internal static readonly MethodInfo SelectMethodInfo
+        = typeof(AsyncEnumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.Select))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 2
+                      && mi.GetParameters().Length == 2);
+
     /// <summary>
     /// Client side execution of Linq method <b>Select</b> with <see cref="IAsyncEnumerable{T}"/> as source. 
     /// </summary>

--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -81,6 +81,69 @@ public static class QueryableAsyncExtensions
         return list;
     }
 
+    #region ElementAt/ElementAtOrDefault
+    
+    /// <summary>
+    ///     Asynchronously returns the element at a specified index in a sequence.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">An <see cref="IQueryable{T}" /> to return the element from.</param>
+    /// <param name="index">The zero-based index of the element to retrieve.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation.
+    ///     The task result contains the element at a specified index in a <paramref name="source" /> sequence.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///     <para>
+    ///         <paramref name="index" /> is less than zero.
+    ///     </para>
+    /// </exception>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public static async Task<TSource> ElementAtAsync<TSource>(this IQueryable<TSource> source, int index,
+        CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        return await source.Skip(index).Take(1).FirstAsync(cancellationToken);
+    }
+    
+    /// <summary>
+    ///     Asynchronously returns the element at a specified index in a sequence, or a default value if the index is out of range.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">An <see cref="IQueryable{T}" /> to return the element from.</param>
+    /// <param name="index">The zero-based index of the element to retrieve.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation.
+    ///     The task result contains the element at a specified index in a <paramref name="source" /> sequence.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public static async Task<TSource?> ElementAtOrDefaultAsync<TSource>(this IQueryable<TSource> source, int index,
+        CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+        if (index < 0)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        return await source.Skip(index).Take(1).FirstOrDefaultAsync(cancellationToken);
+    }
+    
+    #endregion
+
+    #region First/FirstOrDefault
+    
     /// <summary>
     /// Returns the first element of a sequence.
     /// </summary>
@@ -112,7 +175,7 @@ public static class QueryableAsyncExtensions
             throw new InvalidOperationException("The source sequence is empty.");
         }
     }
-
+    
     /// <summary>
     /// Returns the first element of a sequence, or a default value if the sequence contains no elements.
     /// </summary>
@@ -125,7 +188,7 @@ public static class QueryableAsyncExtensions
     /// <exception cref="ArgumentNullException">
     /// <paramref name="source"/> is <c>null</c>.
     /// </exception>
-    public static async Task<TSource?> FirstOrDefault<TSource>(this IQueryable<TSource> source,
+    public static async Task<TSource?> FirstOrDefaultAsync<TSource>(this IQueryable<TSource> source,
         CancellationToken cancellationToken = default)
     {
         if (source == null)
@@ -143,6 +206,8 @@ public static class QueryableAsyncExtensions
         return default(TSource);
     }
 
+    #endregion
+    
     /// <summary>
     /// Creates a <see cref="IResultList{T}"/> from an <see cref="IQueryable{T}"/> which has a Provider implementing <see cref="IAsyncQueryProvider"/>.
     /// </summary>

--- a/src/BccCode.Linq/Extensions/Enumerable.cs
+++ b/src/BccCode.Linq/Extensions/Enumerable.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+
+namespace System.Linq.Internal;
+
+/// <summary>
+/// Internal. Holds reflection helper for extension methods of class <see cref="System.Linq.Enumerable"/>.
+/// </summary>
+internal static class Enumerable
+{
+    internal static readonly MethodInfo FirstMethodInfo
+        = typeof(System.Linq.Enumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.First))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 1
+                      && mi.GetParameters().Length == 1);
+
+    internal static readonly MethodInfo FirstOrDefaultMethodInfo
+        = typeof(System.Linq.Enumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.FirstOrDefault))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 1
+                      && mi.GetParameters().Length == 1);
+    
+    internal static readonly MethodInfo SelectMethodInfo
+        = typeof(System.Linq.Enumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.Select))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 2
+                      && mi.GetParameters().Length == 2
+                      && mi.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2);
+}

--- a/src/BccCode.Linq/Extensions/Enumerable.cs
+++ b/src/BccCode.Linq/Extensions/Enumerable.cs
@@ -28,4 +28,18 @@ internal static class Enumerable
                 mi => mi.GetGenericArguments().Length == 2
                       && mi.GetParameters().Length == 2
                       && mi.GetParameters()[1].ParameterType.GetGenericArguments().Length == 2);
+
+    internal static readonly MethodInfo SingleMethodInfo
+        = typeof(System.Linq.Enumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.Single))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 1
+                      && mi.GetParameters().Length == 1);
+
+    internal static readonly MethodInfo SingleOrDefaultMethodInfo
+        = typeof(System.Linq.Enumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.SingleOrDefault))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 1
+                      && mi.GetParameters().Length == 1);
 }

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -785,6 +785,60 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
                     }
                 }
                     break;
+                case nameof(Queryable.First):
+                {
+                    var source = Visit(node.Arguments[0]);
+                    Debug.Assert(source != null);
+                    if (!TryGetApiCaller(node.Arguments[0], out var apiCaller))
+                    {
+                        // ... the source was not a ApiQueryable and is not
+                        // part of the API. So we just do nothing and pass it
+                    }
+                    else if (node.Arguments.Count == 1)
+                    {
+                        apiCaller.Request.Limit = 1;
+
+                        // We remove here the Take method call from the expression tree,
+                        // because the Take is done by the API.
+                        return Expression.Call(
+                            instance: null,
+                            method: System.Linq.Internal.Enumerable.FirstMethodInfo.MakeGenericMethod(
+                                node.Method.GetGenericArguments()[0]),
+                            arguments: new[] { source });
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Unsupported {node.Method.DeclaringType?.FullName}.{node.Method.Name} signature. The method can only be used without parameters.");
+                    }
+                }
+                    break;
+                case nameof(Queryable.FirstOrDefault):
+                {
+                    var source = Visit(node.Arguments[0]);
+                    Debug.Assert(source != null);
+                    if (!TryGetApiCaller(node.Arguments[0], out var apiCaller))
+                    {
+                        // ... the source was not a ApiQueryable and is not
+                        // part of the API. So we just do nothing and pass it
+                    }
+                    else if (node.Arguments.Count == 1)
+                    {
+                        apiCaller.Request.Limit = 1;
+
+                        // We remove here the Take method call from the expression tree,
+                        // because the Take is done by the API.
+                        return Expression.Call(
+                            instance: null,
+                            method: System.Linq.Internal.Enumerable.FirstOrDefaultMethodInfo.MakeGenericMethod(
+                                node.Method.GetGenericArguments()[0]),
+                            arguments: new[] { source });
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Unsupported {node.Method.DeclaringType?.FullName}.{node.Method.Name} signature. The method can only be used without parameters.");
+                    }
+                }
+                    break;
                 case nameof(Queryable.Where):
                     {
                         //Arg 0: source

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -992,6 +992,60 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
                         }
                         throw new Exception("Syntax of Select expression not supported.");
                     }
+                case nameof(Queryable.Single):
+                {
+                    var source = Visit(node.Arguments[0]);
+                    Debug.Assert(source != null);
+                    if (!TryGetApiCaller(node.Arguments[0], out var apiCaller))
+                    {
+                        // ... the source was not a ApiQueryable and is not
+                        // part of the API. So we just do nothing and pass it
+                    }
+                    else if (node.Arguments.Count == 1)
+                    {
+                        apiCaller.Request.Limit = 2;
+
+                        // We remove here the Take method call from the expression tree,
+                        // because the Take is done by the API.
+                        return Expression.Call(
+                            instance: null,
+                            method: System.Linq.Internal.Enumerable.SingleMethodInfo.MakeGenericMethod(
+                                node.Method.GetGenericArguments()[0]),
+                            arguments: new[] { source });
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Unsupported {node.Method.DeclaringType?.FullName}.{node.Method.Name} signature. The method can only be used without parameters.");
+                    }
+                }
+                    break;
+                case nameof(Queryable.SingleOrDefault):
+                {
+                    var source = Visit(node.Arguments[0]);
+                    Debug.Assert(source != null);
+                    if (!TryGetApiCaller(node.Arguments[0], out var apiCaller))
+                    {
+                        // ... the source was not a ApiQueryable and is not
+                        // part of the API. So we just do nothing and pass it
+                    }
+                    else if (node.Arguments.Count == 1)
+                    {
+                        apiCaller.Request.Limit = 2;
+
+                        // We remove here the Take method call from the expression tree,
+                        // because the Take is done by the API.
+                        return Expression.Call(
+                            instance: null,
+                            method: System.Linq.Internal.Enumerable.SingleOrDefaultMethodInfo.MakeGenericMethod(
+                                node.Method.GetGenericArguments()[0]),
+                            arguments: new[] { source });
+                    }
+                    else
+                    {
+                        throw new NotSupportedException($"Unsupported {node.Method.DeclaringType?.FullName}.{node.Method.Name} signature. The method can only be used without parameters.");
+                    }
+                }
+                    break;
                 case nameof(Queryable.OrderBy):
                 case nameof(Queryable.ThenBy):
                 case nameof(Queryable.OrderByDescending):

--- a/src/BccCode.Linq/QueryProvider/IIncludableQueryable.cs
+++ b/src/BccCode.Linq/QueryProvider/IIncludableQueryable.cs
@@ -1,0 +1,15 @@
+﻿namespace BccCode.Linq;
+
+/// <summary>
+/// Supports queryable Include/ThenInclude chaining operators.
+/// </summary>
+/// <typeparam name="TEntity">The entity type.</typeparam>
+/// <typeparam name="TProperty">The property type.</typeparam>
+/// <remarks>
+/// This is a clone of
+/// <a href="https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.query.iincludablequeryable-2?view=efcore-7.0">
+/// Microsoft.EntityFrameworkCore.Query.IIncludableQueryable</a>
+/// </remarks>
+public interface IIncludableQueryable<out TEntity, out TProperty> : IQueryable<TEntity>
+{
+}

--- a/tests/BccCode.Linq.Tests/Helpers/Person.cs
+++ b/tests/BccCode.Linq.Tests/Helpers/Person.cs
@@ -30,4 +30,12 @@ public class Car
         Model = model;
         YearOfProduction = yearOfProduction;
     }
+    
+    public ManufacturerInfo ManufacturerInfo { get; set; }
+}
+
+public class ManufacturerInfo
+{
+    public string Name { get; set; }
+    public int EstablishedYear { get; set; }
 }

--- a/tests/BccCode.Linq.Tests/Helpers/TestClass.cs
+++ b/tests/BccCode.Linq.Tests/Helpers/TestClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace BccCode.Linq.Tests.Helpers;
 
-internal class TestClass
+public class TestClass
 {
     public string StrProp { get; set; }
     public string AnotherStrProp { get; set; }
@@ -17,7 +17,7 @@ internal class TestClass
     public NestedClass Nested { get; set; }
 }
 
-internal class NestedClass
+public class NestedClass
 {
 
     public string NestedStrProp { get; set; }

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -340,6 +340,105 @@ public class LinqQueryProviderTests
 
     #endregion
 
+    #region Single
+
+    [Fact]
+    public void SingleTest()
+    {
+        var api = new ApiClientMockup();
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var persons = api.Persons.Single();
+        });
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(2, api.LastRequest?.Limit);
+    }
+    
+    [Fact]
+    public void SingleAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            var persons = await api.Persons.SingleAsync();
+        });
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(2, api.LastRequest?.Limit);
+    }
+
+    #endregion
+
+    #region SingleOrDefault
+
+    [Fact] public void SingleOrDefaultTest()
+    {
+        var api = new ApiClientMockup();
+
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var persons = api.Persons.SingleOrDefault();
+        });
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(2, api.LastRequest?.Limit);
+    }
+    
+    [Fact]
+    public void SingleOrDefaultEmptyTest()
+    {
+        var api = new ApiClientMockup();
+
+        var testClass = api.Empty.SingleOrDefault();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(2, api.LastRequest?.Limit);
+        Assert.Null(testClass);
+    }
+    
+    [Fact]
+    public void SingleOrDefaultAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            var persons = await api.Persons.SingleOrDefaultAsync();
+        });
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(2, api.LastRequest?.Limit);
+    }
+    
+    [Fact]
+    public async void SingleOrDefaultEmptyAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var testClass = await api.Empty.SingleOrDefaultAsync();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(2, api.LastRequest?.Limit);
+        Assert.Null(testClass);
+    }
+    
+    #endregion
+    
     #region Where
 
     [Fact]

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -113,6 +113,98 @@ public class LinqQueryProviderTests
     }
 
     #endregion
+
+    #region First
+
+    [Fact]
+    public void FirstTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = api.Persons.First();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Equal("Archibald Mcbride", persons.Name);
+    }
+    
+    [Fact]
+    public async void FirstAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = await api.Persons.FirstAsync();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Equal("Archibald Mcbride", persons.Name);
+    }
+
+    #endregion
+    
+    #region FirstOrDefault
+
+    [Fact]
+    public void FirstOrDefaultTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = api.Persons.FirstOrDefault();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Equal("Archibald Mcbride", persons?.Name);
+    }
+    
+    [Fact]
+    public void FirstOrDefaultEmptyTest()
+    {
+        var api = new ApiClientMockup();
+
+        var testClass = api.Empty.FirstOrDefault();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Null(testClass);
+    }
+    
+    [Fact]
+    public async void FirstOrDefaultAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = await api.Persons.FirstOrDefaultAsync();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Equal("Archibald Mcbride", persons?.Name);
+    }
+    
+    [Fact]
+    public async void FirstOrDefaultEmptyAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var testClass = await api.Empty.FirstOrDefaultAsync();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Null(testClass);
+    }
+
+    #endregion
     
     #region Select
 

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -96,6 +96,20 @@ public class LinqQueryProviderTests
     }
     
     [Fact]
+    public void ElementAtOrDefaultEmptyTest()
+    {
+        var api = new ApiClientMockup();
+
+        var testClass = api.Empty.ElementAtOrDefault(0);
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(0, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.Null(testClass);
+    }
+    
+    [Fact]
     public async void ElementAtOrDefaultNotFoundAsyncTest()
     {
         var api = new ApiClientMockup();

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -817,6 +817,49 @@ public class LinqQueryProviderTests
         //Assert.Equal(3, persons.Count);
         Assert.Equal(5, persons.Count);
     }
+    
+    [Fact]
+    public void IncludeSecondNestedTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Persons
+            .Include(p => p.Car.Manufacturer);
+
+        var persons = query.ToList();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Null(api.LastRequest?.Filter);
+        Assert.Equal("*,car.manufacturer.*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
+        //       from the expression tree, the result will be still the total count of the mockup data.
+        //Assert.Equal(3, persons.Count);
+        Assert.Equal(5, persons.Count);
+    }
+    
+    [Fact]
+    public void IncludeThenIncludeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Persons
+            .Include(p => p.Car)
+                .ThenInclude(c => c.ManufacturerInfo);
+
+        var persons = query.ToList();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Null(api.LastRequest?.Filter);
+        Assert.Equal("*,car.*,car.manufacturerInfo.*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
+        //       from the expression tree, the result will be still the total count of the mockup data.
+        //Assert.Equal(3, persons.Count);
+        Assert.Equal(5, persons.Count);
+    }
 
     #endregion
 }

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -4,6 +4,116 @@ namespace BccCode.Linq.Tests;
 
 public class LinqQueryProviderTests
 {
+    #region ElementAt
+
+    [Fact]
+    public void ElementAtTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = api.Persons.ElementAt(2);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(2, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
+        //       from the expression tree, the result will be still the first element of the mockup data.
+        //Assert.Equal("Chelsey Logan", persons.Name);
+        Assert.Equal("Archibald Mcbride", persons.Name);
+    }
+    
+    [Fact]
+    public async void ElementAtAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = await api.Persons.ElementAtAsync(2);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(2, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
+        //       from the expression tree, the result will be still the first element of the mockup data.
+        //Assert.Equal("Chelsey Logan", persons.Name);
+        Assert.Equal("Archibald Mcbride", persons.Name);
+    }
+    
+    #endregion
+
+    #region ElementAtOrDefault
+    
+    [Fact]
+    public void ElementAtOrDefaultTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = api.Persons.ElementAtOrDefault(2);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(2, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
+        //       from the expression tree, the result will be still the first element of the mockup data.
+        //Assert.Equal("Chelsey Logan", persons.Name);
+        Assert.Equal("Archibald Mcbride", persons?.Name);
+    }
+    
+    [Fact]
+    public async void ElementAtOrDefaultAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = await api.Persons.ElementAtOrDefaultAsync(2);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(2, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
+        //       from the expression tree, the result will be still the first element of the mockup data.
+        //Assert.Equal("Chelsey Logan", persons.Name);
+        Assert.Equal("Archibald Mcbride", persons?.Name);
+    }
+    
+    [Fact]
+    public void ElementAtOrDefaultNotFoundTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = api.Persons.ElementAtOrDefault(int.MaxValue);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(int.MaxValue, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
+        //       from the expression tree, the result will be still the first element of the mockup data.
+        //Assert.Equal(null, persons.Name);
+        Assert.Equal("Archibald Mcbride", persons?.Name);
+    }
+    
+    [Fact]
+    public async void ElementAtOrDefaultNotFoundAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var persons = await api.Persons.ElementAtOrDefaultAsync(int.MaxValue);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Equal(int.MaxValue, api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
+        //       from the expression tree, the result will be still the first element of the mockup data.
+        //Assert.Equal(null, persons.Name);
+        Assert.Equal("Archibald Mcbride", persons?.Name);
+    }
+
+    #endregion
+    
     #region Select
 
     [Fact]

--- a/tests/BccCode.Linq.Tests/Mockups/ApiClientMockup.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiClientMockup.cs
@@ -9,10 +9,12 @@ public class ApiClientMockup : ApiClientMockupBase
     {
         // registering seeds data ...
         RegisterData(typeof(Person), Seeds.Persons);
+        RegisterData(typeof(TestClass), Array.Empty<TestClass>());
         RegisterData(typeof(ManufacturerInfo), Seeds.Manufacturers);
     }
 
     // strongly typed entities
     public IQueryable<Person> Persons => this.GetQueryable<Person>("persons");
+    public IQueryable<TestClass> Empty => this.GetQueryable<TestClass>("empty");
     public IQueryable<ManufacturerInfo> Manufacturers => this.GetQueryable<ManufacturerInfo>("manufacturers");
 }

--- a/tests/BccCode.Linq.Tests/Mockups/ApiClientMockup.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiClientMockup.cs
@@ -9,8 +9,10 @@ public class ApiClientMockup : ApiClientMockupBase
     {
         // registering seeds data ...
         RegisterData(typeof(Person), Seeds.Persons);
+        RegisterData(typeof(ManufacturerInfo), Seeds.Manufacturers);
     }
 
     // strongly typed entities
     public IQueryable<Person> Persons => this.GetQueryable<Person>("persons");
+    public IQueryable<ManufacturerInfo> Manufacturers => this.GetQueryable<ManufacturerInfo>("manufacturers");
 }

--- a/tests/BccCode.Linq.Tests/Mockups/Seeds.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/Seeds.cs
@@ -6,6 +6,7 @@ namespace BccCode.Linq.Tests;
 internal static class Seeds
 {
     private static IReadOnlyCollection<Person>? _persons;
+    private static IReadOnlyCollection<ManufacturerInfo>? _manufacturers;
 
     public static IReadOnlyCollection<Person> Persons
         => _persons ??= ImmutableList.Create(new Person[]
@@ -20,6 +21,16 @@ internal static class Seeds
             {
                 Car = new Car("Opel", "Astra", 2019)
             },
-            new("Amelie Beasley", 75, "PL", new DateTime(1982, 12, 24)),
+            new("Amelie Beasley", 75, "PL", new DateTime(1982, 12, 24))
+            {
+                Car = new Car("Volkswagen", "Golf", 2020)
+            },
+        });
+
+    public static IReadOnlyCollection<ManufacturerInfo> Manufacturers
+        => _manufacturers ??= ImmutableList.Create(new[]
+        {
+            new ManufacturerInfo { Name = "Opel", EstablishedYear = 1862 },
+            new ManufacturerInfo { Name = "Volkswagen", EstablishedYear = 1937 }
         });
 }


### PR DESCRIPTION
closes #40 

### Implements
* `ThenInclude` #40
* `ElementAt`/`ElementAtOrDefault` #28 (sync/async)
* `First`/`FirstOrDefault` #28 (sync, async was already implemented)
* fix rename async method `FirstOrDefault` to `FirstOrDefaultAsync` #29
