### PR TITLE
add metadata properties

### DIFF
--- a/src/BccCode.Linq/ApiClient/ApiPagedEnumerable.cs
+++ b/src/BccCode.Linq/ApiClient/ApiPagedEnumerable.cs
@@ -13,7 +13,7 @@ internal interface IApiCaller : IEnumerable
 
 internal class ResultList<TEntity> : IResultList<TEntity>
 {
-    public IReadOnlyDictionary<string, object> Meta { get; set; }
+    public IMetadata? Meta { get; set; }
     public List<TEntity> Data { get; } = new();
 
     IReadOnlyList<TEntity> IResultList<TEntity>.Data => Data;

--- a/src/BccCode.Linq/ApiClient/IMeta.cs
+++ b/src/BccCode.Linq/ApiClient/IMeta.cs
@@ -2,5 +2,5 @@
 
 public interface IMeta
 {
-    IReadOnlyDictionary<string, object> Meta { get; }
+    IMetadata? Meta { get; }
 }

--- a/src/BccCode.Linq/ApiClient/IMetadata.cs
+++ b/src/BccCode.Linq/ApiClient/IMetadata.cs
@@ -1,0 +1,38 @@
+﻿namespace BccCode.Linq.ApiClient;
+
+public interface IMetadata : IReadOnlyDictionary<string, object>
+{
+    /// <summary>
+    /// Returns the page limit of the request.
+    /// </summary>
+    public int Limit =>
+        this.TryGetValue("limit", out var limit) ? (int)limit : default;
+
+    /// <summary>
+    /// Returns how many rows have been skipped from the start.
+    /// </summary>
+    public int Skipped =>
+        this.TryGetValue("skipped", out var skipped) ? (int)skipped : default;
+
+    /// <summary>
+    /// Returns the number of rows, passed by the metadata property <c>"total"</c>.
+    /// </summary>
+    [Obsolete($"Please use either property {nameof(FilterCount)} instead.")]
+    public int Total =>
+        this.TryGetValue("total", out var total) ? (int)total : default;
+
+    /// <summary>
+    /// Returns the item count of the collection you're querying, taking the current filter/search parameters into account
+    /// if given, otherwise <c>null</c>.
+    /// </summary>
+    public long? FilterCount =>
+        this.TryGetValue("filter_count", out var filterCount) ? (long?)filterCount
+        : this.TryGetValue("total", out var total) ? (int)total
+        : null;
+
+    /// <summary>
+    /// Returns the total item count of the collection you're querying if given, otherwise <c>null</c>.
+    /// </summary>
+    public long? TotalCount =>
+        this.TryGetValue("total_count", out var totalCount) ? (long?)totalCount : null;
+}

--- a/src/BccCode.Linq/ApiClient/Metadata.cs
+++ b/src/BccCode.Linq/ApiClient/Metadata.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections;
+using BccCode.Linq.ApiClient;
+
+namespace BccCode.Linq.Tests;
+
+public class Metadata : IMetadata
+{
+    private readonly IReadOnlyDictionary<string, object>? _dict;
+
+    public Metadata()
+    {
+        _dict = new Dictionary<string, object>();
+    }
+
+    public Metadata(IReadOnlyDictionary<string, object>? dict)
+    {
+        _dict = dict;
+    }
+
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+    {
+        return _dict?.GetEnumerator() ?? Enumerable.Empty<KeyValuePair<string, object>>().GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return _dict?.GetEnumerator() ?? Enumerable.Empty<KeyValuePair<string, object>>().GetEnumerator();
+    }
+
+    public int Count => _dict?.Count ?? 0;
+    public bool ContainsKey(string key)
+    {
+        return _dict?.ContainsKey(key) ?? false;
+    }
+
+    public bool TryGetValue(string key, out object? value)
+    {
+        if (_dict == null)
+        {
+            value = default;
+            return false;
+        }
+        
+        return _dict.TryGetValue(key, out value);
+    }
+
+    public object this[string key] => _dict?[key] ?? throw new KeyNotFoundException();
+
+    public IEnumerable<string> Keys => _dict?.Keys ?? Enumerable.Empty<string>();
+    public IEnumerable<object> Values => _dict?.Values ?? Enumerable.Empty<object>();
+}

--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -215,7 +215,7 @@ public static class QueryableAsyncExtensions
     /// The <see cref="IQueryable{T}"/> to create a <see cref="IResultList{T}"/> from.
     /// </param>
     /// <param name="cancellationToken"></param>
-    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.<</typeparam>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
     /// <returns>
     /// A <see cref="IResultList{T}"/> that contains elements from the input sequence with the metadata from the first page.
     /// </returns>

--- a/tests/BccCode.Linq.Tests/Mockups/ApiClientMockupBase.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiClientMockupBase.cs
@@ -17,16 +17,16 @@ public class ApiClientMockupBase : IApiClient
         public ResultList(List<T> data, Dictionary<string, object>? meta)
         {
             Data = data;
-            Meta = meta ?? new Dictionary<string, object>();
+            Meta = new Metadata(meta);
         }
 
         public List<T> Data { get; }
-        public Dictionary<string, object> Meta { get; }
+        public IMetadata Meta { get; }
 
         #region IResultList<T>
 
         IReadOnlyList<T> IResultList<T>.Data => Data;
-        IReadOnlyDictionary<string, object> IMeta.Meta => Meta;
+        IMetadata IMeta.Meta => Meta;
 
         #endregion
     }
@@ -43,7 +43,11 @@ public class ApiClientMockupBase : IApiClient
 
         var listType = typeof(List<>).MakeGenericType(type);
         var inMemoryList = Activator.CreateInstance(listType, enumerable);
+#pragma warning disable CS8604
+#pragma warning disable CS8600
         _inMemoryData.Add(type, (IList)inMemoryList);
+#pragma warning restore CS8600
+#pragma warning restore CS8604
     }
 
     #region IApiClient


### PR DESCRIPTION
This adds properties to the Metadata object. In addition to the already existing metadata objects `Limit`/`Skipped`/`Total` we added `FilterCount` and `TotalCount`. `Total` is marked as obsolete, `FilterCount` should be used instead (which uses a fallback to metadata object `total` if `filter_count` is not given).

The goal is to not have breaking changes in the core API, see PR https://github.com/bcc-code/bcc-core-api/pull/289