### PR TITLE
add client side invocation logic for constants, member and method calls

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -8,15 +8,15 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.3
 
       - name: Add dotnet-format problem matcher
-        uses: xt0rted/dotnet-format-problem-matcher@v1
+        uses: xt0rted/dotnet-format-problem-matcher@v1.2.0
 
       - name: Restore dotnet tools
-        uses: xt0rted/dotnet-tool-restore@v1
+        uses: xt0rted/dotnet-tool-restore@v1.0.1
 
       - name: Run dotnet format
-        uses: xt0rted/dotnet-format@v1
+        uses: xt0rted/dotnet-format@v1.2.0
         with:
           only-changed-files: "true"

--- a/src/BccCode.Linq/BccCode.Linq.csproj
+++ b/src/BccCode.Linq/BccCode.Linq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -147,7 +147,13 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
             _visitMode = VisitLinqLambdaMode.Undefined;
             Debug.Assert(_mapFromToApiCallers.Count == 0);
             Debug.Assert(_includeChain == null);
-            Expression? translatedExpression = this.Visit(expression);
+            Expression? translatedExpression = this.Visit(Evaluator.PartialEval(
+                expression,
+                fnCanBeEvaluated: e => e.NodeType != ExpressionType.Parameter &&
+                                       !(e is ConstantExpression constantExpression &&
+                                         constantExpression.Type.IsGenericType &&
+                                         constantExpression.Type.GetGenericTypeDefinition() == typeof(ApiQueryable<>))
+                ));
             Debug.Assert(_activeParameters.Count == 0);
             Debug.Assert(translatedExpression != null);
 

--- a/src/BccCode.Linq/QueryProvider/Evaluator.cs
+++ b/src/BccCode.Linq/QueryProvider/Evaluator.cs
@@ -1,0 +1,125 @@
+﻿using System.Linq.Expressions;
+
+namespace BccCode.Linq;
+
+/// <summary>
+///
+/// Reference: <a href="https://msdn.microsoft.com/en-us/library/bb546158.aspx">Walkthrough: Creating an IQueryable LINQ Provider</a>.
+/// </summary>
+internal class Evaluator
+{
+    /// <summary>
+    /// Performs evaluation and replacement of independent sub-trees
+    /// </summary>
+    /// <param name="expression">The root of the expression tree.</param>
+    /// <param name="fnCanBeEvaluated">A function that decides whether a given expression node can be part of the local function.</param>
+    /// <returns>A new tree with sub-trees evaluated and replaced.</returns>
+    public static Expression PartialEval(Expression expression, Func<Expression, bool> fnCanBeEvaluated)
+    {
+        return new SubtreeEvaluator(new Nominator(fnCanBeEvaluated).Nominate(expression)).Eval(expression);
+    }
+
+    /// <summary>
+    /// Performs evaluation and replacement of independent sub-trees 
+    /// </summary>
+    /// <param name="expression">The root of the expression tree.</param>
+    /// <returns>A new tree with sub-trees evaluated and replaced.</returns> 
+    public static Expression PartialEval(Expression expression)
+    {
+        return PartialEval(expression, CanBeEvaluatedLocally);
+    }
+
+    private static bool CanBeEvaluatedLocally(Expression expression)
+    {
+        return expression.NodeType != ExpressionType.Parameter;
+    }
+
+    /// <summary>
+    /// Evaluates and replaces sub-trees when first candidate is reached (top-down) 
+    /// </summary>
+    private class SubtreeEvaluator : ExpressionVisitor
+    {
+        private readonly HashSet<Expression> _candidates;
+
+        internal SubtreeEvaluator(HashSet<Expression> candidates)
+        {
+            this._candidates = candidates;
+        }
+
+        internal Expression Eval(Expression exp)
+        {
+            return this.Visit(exp);
+        }
+
+        public override Expression Visit(Expression exp)
+        {
+            if (exp == null)
+                return null;
+
+            if (this._candidates.Contains(exp))
+            {
+                return this.Evaluate(exp);
+            }
+
+            return base.Visit(exp);
+        }
+
+        private Expression Evaluate(Expression e)
+        {
+            if (e.NodeType == ExpressionType.Constant)
+                return e;
+
+            LambdaExpression lambda = Expression.Lambda(e);
+            Delegate fn = lambda.Compile();
+            return Expression.Constant(fn.DynamicInvoke(null), e.Type);
+        }
+    }
+
+    /// <summary>
+    /// Performs bottom-up analysis to determine which nodes can possibly
+    /// be part of an evaluated sub-tree.
+    /// </summary>
+    private class Nominator : ExpressionVisitor
+    {
+        private readonly Func<Expression, bool> _fnCanBeEvaluated;
+        private readonly HashSet<Expression> _candidates = new();
+        private bool _cannotBeEvaluated;
+
+        internal Nominator(Func<Expression, bool> fnCanBeEvaluated)
+        {
+            this._fnCanBeEvaluated = fnCanBeEvaluated;
+        }
+
+        internal HashSet<Expression> Nominate(Expression expression)
+        {
+            _candidates.Clear();
+            this.Visit(expression);
+            return this._candidates;
+        }
+
+        public override Expression Visit(Expression expression)
+        {
+            if (expression == null)
+                return null;
+
+            bool saveCannotBeEvaluated = this._cannotBeEvaluated;
+            this._cannotBeEvaluated = false;
+            base.Visit(expression);
+            if (!this._cannotBeEvaluated)
+            {
+                if (this._fnCanBeEvaluated(expression))
+                {
+                    this._candidates.Add(expression);
+                }
+                else
+                {
+                    this._cannotBeEvaluated = true;
+                }
+            }
+
+            this._cannotBeEvaluated |= saveCannotBeEvaluated;
+
+            return expression;
+        }
+    }
+}

--- a/src/BccCode.Linq/TypeHelper.cs
+++ b/src/BccCode.Linq/TypeHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace BccCode.Linq;
+﻿using System.Numerics;
+
+namespace BccCode.Linq;
 
 internal static class TypeHelper
 {
@@ -66,5 +68,27 @@ internal static class TypeHelper
             return false;
 
         return IsAssignableToGenericType(baseType, genericType);
+    }
+
+#if NET7_0_OR_GREATER
+#else
+    private static readonly HashSet<Type> NumericTypes = new()
+    {
+        typeof(int),  typeof(double),  typeof(decimal),
+        typeof(long), typeof(short),   typeof(sbyte),
+        typeof(byte), typeof(ulong),   typeof(ushort),
+        typeof(uint), typeof(float),   typeof(BigInteger)
+    };
+#endif
+    
+    public static bool IsNumberType(Type type)
+    {
+#if NET7_0_OR_GREATER
+        var numType = typeof(INumber<>);
+        var result = type.GetInterfaces().Any(i => i.IsGenericType && (i.GetGenericTypeDefinition() == numType));
+        return result;
+#else
+        return NumericTypes.Contains(type);
+#endif
     }
 }

--- a/tests/BccCode.Linq.Tests/Helpers/Person.cs
+++ b/tests/BccCode.Linq.Tests/Helpers/Person.cs
@@ -36,6 +36,7 @@ public class Car
 
 public class ManufacturerInfo
 {
+    public Guid Uid { get; set; }
     public string Name { get; set; }
     public int EstablishedYear { get; set; }
 }

--- a/tests/BccCode.Linq.Tests/Helpers/TestClass.cs
+++ b/tests/BccCode.Linq.Tests/Helpers/TestClass.cs
@@ -15,6 +15,11 @@ public class TestClass
     public DateTime AnyDate { get; set; }
     public DateTime? DateNullable { get; set; }
     public NestedClass Nested { get; set; }
+    public Guid Uuid { get; set; }
+    public Guid? UuidNullable { get; set; }
+#if NET6_0_OR_GREATER
+    public DateOnly DateOnly { get; set; }
+#endif
 }
 
 public class NestedClass

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -557,6 +557,367 @@ public class LinqQueryProviderTests
         */
     }
 
+    public void WhereStringEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.StrProp == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereStringEqualToEmptyStringTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.StrProp == ""
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": \"\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereIntegerEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.NumberIntergerProp == 5
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"numberIntergerProp\": {\"_eq\": 5}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereIntegerNullableEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.IntNullable == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"intNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereIntegerNullableEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.IntNullable == 5
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"intNullable\": {\"_eq\": 5}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDoubleEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.NumberDoubleProp == -5.13
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"numberDoubleProp\": {\"_eq\": -5.13}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereLongEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.NumberLongProp == 3372036854775807
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"numberLongProp\": {\"_eq\": 3372036854775807}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereBoolEqualToTrueTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.BooleanProp == true
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"booleanProp\": {\"_eq\": true}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDecimalEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.Amount == 312312.5434353m
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"amount\": {\"_eq\": 312312.5434353}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDecimalNullableEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.AmountNullable == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"amountNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDecimalNullableEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.AmountNullable == 312312.5434353m
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"amountNullable\": {\"_eq\": 312312.5434353}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDateTimeEqualToDateTimeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.AnyDate != new DateTime(2013, 12, 4, 4, 2, 5)
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-4T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDateTimeNullableEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.DateNullable == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDateTimeNullableEqualToDateTimeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.DateNullable == new DateTime(2013, 12, 4, 4, 2, 5)
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-4T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void WhereDateOnlyNullableEqualToDateTimeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.DateOnly != new DateOnly(2013, 12, 4)
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-4\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+#endif
+    
+    [Fact]
+    public void WhereGuidEqualToGuidTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.Uuid == new Guid("00000000-0000-0000-0000-000000000000")
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuid\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereGuidNullableEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.UuidNullable == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereGuidNullableEqualToGuidTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.UuidNullable == new Guid("00000000-0000-0000-0000-000000000000")
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+
     [Fact]
     public void WhereIntGreaterThanTest()
     {

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -787,12 +787,12 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.AnyDate != new DateTime(2013, 12, 4, 4, 2, 5)
+            where p.AnyDate == new DateTime(2013, 12, 4, 4, 2, 5, DateTimeKind.Utc)
             select p;
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2013-12-04T04:02:05.0000000Z\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -827,12 +827,12 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.DateNullable == new DateTime(2013, 12, 4, 4, 2, 5)
+            where p.DateNullable == new DateTime(2013, 12, 4, 4, 2, 5, DateTimeKind.Utc)
             select p;
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2013-12-04T04:02:05.0000000Z\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -848,12 +848,12 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.DateOnly != new DateOnly(2013, 12, 4)
+            where p.DateOnly == new DateOnly(2013, 12, 4)
             select p;
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-04\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2013-12-04\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -976,14 +976,10 @@ public class LinqQueryProviderTests
             where p.NumberIntergerProp.ToString() == "5"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"numberIntergerProp\": {\"_eq\": 5}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -996,14 +992,10 @@ public class LinqQueryProviderTests
             where p.IntNullable.ToString() == null
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"intNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1016,14 +1008,10 @@ public class LinqQueryProviderTests
             where p.IntNullable.ToString() == "5"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"intNullable\": {\"_eq\": \"5\"}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1033,17 +1021,14 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.NumberDoubleProp.ToString(CultureInfo.InvariantCulture) == "-5.13"
+            // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+            where p.NumberDoubleProp.ToString() == "-5.13"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"numberDoubleProp\": {\"_eq\": \"-5.13\"}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1053,17 +1038,13 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.NumberLongProp.ToString(CultureInfo.InvariantCulture) == "3372036854775807"
+            where p.NumberLongProp.ToString() == "3372036854775807"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"numberLongProp\": {\"_eq\": \"3372036854775807\"}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1076,14 +1057,10 @@ public class LinqQueryProviderTests
             where p.BooleanProp.ToString() == "True"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"booleanProp\": {\"_eq\": \"True\"}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1093,17 +1070,14 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.Amount.ToString(CultureInfo.InvariantCulture) == "312312.5434353"
+            // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+            where p.Amount.ToString() == "312312.5434353"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"amount\": {\"_eq\": \"312312.5434353\"}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1116,14 +1090,10 @@ public class LinqQueryProviderTests
             where p.AmountNullable.ToString() == null
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"amountNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1136,14 +1106,10 @@ public class LinqQueryProviderTests
             where p.AmountNullable.ToString() == "312312.5434353"
             select p;
 
-        var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"amountNullable\": {\"_eq\": \"312312.5434353\"}}", api.LastRequest?.Filter);
-        Assert.Equal("*", api.LastRequest?.Fields);
-        Assert.Null(api.LastRequest?.Sort);
-        Assert.Null(api.LastRequest?.Offset);
-        Assert.Null(api.LastRequest?.Limit);
-        Assert.Empty(persons);
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var persons = query.ToList();
+        });
     }
     
     [Fact]
@@ -1153,12 +1119,13 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.AnyDate.ToString(CultureInfo.InvariantCulture) != "2023-12-04T04:02:05Z"
+            // ReSharper disable once SpecifyACultureInStringConversionExplicitly
+            where p.AnyDate.ToString() == "2023-12-04T04:02:05Z"
             select p;
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-4T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -1214,12 +1181,12 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
-            where p.DateOnly.ToString() == "2023-12-4"
+            where p.DateOnly.ToString() == "2023-12-04"
             select p;
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-4\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-04\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -1,4 +1,5 @@
-﻿using BccCode.Linq.Async;
+﻿using System.Globalization;
+using BccCode.Linq.Async;
 
 namespace BccCode.Linq.Tests;
 
@@ -445,6 +446,8 @@ public class LinqQueryProviderTests
     
     #region Where
 
+    #region Where property equal to ...
+    
     [Fact]
     public void WhereGuidEqualStaticNewTest()
     {
@@ -663,6 +666,7 @@ public class LinqQueryProviderTests
 
         var query =
             from p in api.Empty
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
             where p.NumberDoubleProp == -5.13
             select p;
 
@@ -788,7 +792,7 @@ public class LinqQueryProviderTests
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-4T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -828,7 +832,7 @@ public class LinqQueryProviderTests
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-4T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -849,7 +853,7 @@ public class LinqQueryProviderTests
 
         var persons = query.ToList();
         Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-4\"}}", api.LastRequest?.Filter);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-04\"}}", api.LastRequest?.Filter);
         Assert.Equal("*", api.LastRequest?.Fields);
         Assert.Null(api.LastRequest?.Sort);
         Assert.Null(api.LastRequest?.Offset);
@@ -917,6 +921,374 @@ public class LinqQueryProviderTests
         Assert.Null(api.LastRequest?.Limit);
         Assert.Empty(persons);
     }
+
+    #endregion
+
+    #region Where property.ToString() to ...
+
+    [Fact]
+    public void WhereStringToStringEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.StrProp.ToString() == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereStringToStringEqualToEmptyStringTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.StrProp.ToString() == ""
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": \"\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereIntegerToStringEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.NumberIntergerProp.ToString() == "5"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"numberIntergerProp\": {\"_eq\": 5}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereIntegerNullableToStringEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.IntNullable.ToString() == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"intNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereIntegerNullableToStringEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.IntNullable.ToString() == "5"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"intNullable\": {\"_eq\": \"5\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDoubleToStringEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.NumberDoubleProp.ToString(CultureInfo.InvariantCulture) == "-5.13"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"numberDoubleProp\": {\"_eq\": \"-5.13\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereLongToStringEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.NumberLongProp.ToString(CultureInfo.InvariantCulture) == "3372036854775807"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"numberLongProp\": {\"_eq\": \"3372036854775807\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereBoolToStringEqualToTrueTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.BooleanProp.ToString() == "True"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"booleanProp\": {\"_eq\": \"True\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDecimalToStringEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.Amount.ToString(CultureInfo.InvariantCulture) == "312312.5434353"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"amount\": {\"_eq\": \"312312.5434353\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDecimalNullableToStringEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.AmountNullable.ToString() == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"amountNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDecimalNullableToStringEqualToNumberTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.AmountNullable.ToString() == "312312.5434353"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"amountNullable\": {\"_eq\": \"312312.5434353\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDateTimeToStringEqualToDateTimeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.AnyDate.ToString(CultureInfo.InvariantCulture) != "2023-12-04T04:02:05Z"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-4T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDateTimeNullableToStringEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.DateNullable.ToString() == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereDateTimeNullableToStringEqualToDateTimeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.DateNullable.ToString() == "2023-12-04T04:02:05Z"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+#if NET6_0_OR_GREATER
+    [Fact]
+    public void WhereDateOnlyToStringEqualToDateTimeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.DateOnly.ToString() == "2023-12-4"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-4\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+#endif
+    
+    [Fact]
+    public void WhereGuidToStringEqualToGuidTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.Uuid.ToString() == "00000000-0000-0000-0000-000000000000"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuid\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+
+    [Fact]
+    public void WhereGuidNullableToStringEqualToNullTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.UuidNullable.ToString() == null
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": null}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+    
+    [Fact]
+    public void WhereGuidNullableToStringEqualToGuidTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where p.UuidNullable.ToString() == "00000000-0000-0000-0000-000000000000"
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+
+    #endregion
 
     [Fact]
     public void WhereIntGreaterThanTest()

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using BccCode.Linq.Async;
+﻿using BccCode.Linq.Async;
 
 namespace BccCode.Linq.Tests;
 
@@ -537,14 +536,6 @@ public class LinqQueryProviderTests
             where m.Uid.ToString() == "16b41e40-ee3c-4837-b9a9-57b76c7d1d9d"
             select m;
 
-        Assert.Throws<NotSupportedException>(() =>
-            {
-                // ReSharper disable once UnusedVariable
-                var manufacturer = query.FirstOrDefault();
-            }
-        );
-        
-        /*
         var manufacturer = query.FirstOrDefault();
         Assert.Equal("manufacturers", api.LastEndpoint);
         Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.LastRequest?.Filter);
@@ -557,7 +548,6 @@ public class LinqQueryProviderTests
         //       from the expression tree, the result will be still the first row of the mockup data.
         //Assert.Equal(new Guid("16b41e40-ee3c-4837-b9a9-57b76c7d1d9d"), manufacturer?.Uid);
         Assert.Equal(new Guid("4477e983-be5c-43d5-b3d0-5f26971bf2f3"), manufacturer?.Uid);
-        */
     }
 
     public void WhereStringEqualToNullTest()

--- a/tests/BccCode.Linq.Tests/Mockups/Seeds.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/Seeds.cs
@@ -30,7 +30,7 @@ internal static class Seeds
     public static IReadOnlyCollection<ManufacturerInfo> Manufacturers
         => _manufacturers ??= ImmutableList.Create(new[]
         {
-            new ManufacturerInfo { Name = "Opel", EstablishedYear = 1862 },
-            new ManufacturerInfo { Name = "Volkswagen", EstablishedYear = 1937 }
+            new ManufacturerInfo { Uid = new Guid("4477e983-be5c-43d5-b3d0-5f26971bf2f3"), Name = "Opel", EstablishedYear = 1862 },
+            new ManufacturerInfo { Uid = new Guid("16b41e40-ee3c-4837-b9a9-57b76c7d1d9d"), Name = "Volkswagen", EstablishedYear = 1937 }
         });
 }

--- a/tests/BccCode.Linq.Tests/QueryableConverterTests.cs
+++ b/tests/BccCode.Linq.Tests/QueryableConverterTests.cs
@@ -5,7 +5,7 @@ public class QueryableConverterTests
     [Fact]
     public void EqualQuery()
     {
-        var json = DirectusFilterBuilder<Project>.Create()
+        var json = new DirectusFilterBuilder<Project>()
             .Where(x => x.Status == true)
             .Serialize();
 
@@ -13,9 +13,19 @@ public class QueryableConverterTests
     }
 
     [Fact]
+    public void NotEqualQuery()
+    {
+        var json = new DirectusFilterBuilder<Project>()
+            .Where(x => x.Status != true)
+            .Serialize();
+
+        Assert.Equal("{\"Status\":{\"_neq\":\"True\"}}", json);
+    }
+
+    [Fact]
     public void BetweenTwoDatesQuery()
     {
-        var query = DirectusFilterBuilder<Project>.Create()
+        var query = new DirectusFilterBuilder<Project>()
             .Where(x => x.Start >= new DateTime(2023, 5, 1) && x.Start <= new DateTime(2023, 5, 31));
 
         var json = query.Serialize();
@@ -28,7 +38,7 @@ public class QueryableConverterTests
     {
         var defaultFrom = DateTime.UtcNow.AddMonths(-6);
         var defaultTo = DateTime.UtcNow;
-        var defaultFilterJson = DirectusFilterBuilder<Project>.Create()
+        var defaultFilterJson = new DirectusFilterBuilder<Project>()
             .Where(x => x.Start >= defaultFrom && x.Start <= defaultTo)
             .Serialize();
 
@@ -38,7 +48,7 @@ public class QueryableConverterTests
     [Fact]
     public void GreaterThanOrEqual()
     {
-        var json = DirectusFilterBuilder<Project>.Create()
+        var json = new DirectusFilterBuilder<Project>()
             .Where(x => x.Start >= new DateTime(2023, 5, 1))
             .Serialize();
 
@@ -48,7 +58,7 @@ public class QueryableConverterTests
     [Fact]
     public void GreaterThan()
     {
-        var json = DirectusFilterBuilder<Project>.Create()
+        var json = new DirectusFilterBuilder<Project>()
             .Where(x => x.Start > new DateTime(2023, 5, 1))
             .Serialize();
 
@@ -58,7 +68,7 @@ public class QueryableConverterTests
     [Fact]
     public void LessThanOrEqual()
     {
-        var json = DirectusFilterBuilder<Project>.Create()
+        var json = new DirectusFilterBuilder<Project>()
             .Where(x => x.Start <= new DateTime(2023, 5, 1))
             .Serialize();
 
@@ -68,7 +78,7 @@ public class QueryableConverterTests
     [Fact]
     public void LessThan()
     {
-        var json = DirectusFilterBuilder<Project>.Create()
+        var json = new DirectusFilterBuilder<Project>()
             .Where(x => x.Start < new DateTime(2023, 5, 1))
             .Serialize();
 


### PR DESCRIPTION
Hi Reng,

I found out that we need some client-side invocation logic on expression visiting time. E.g. it was not possible to run this query
``` C#
var query =
    from p in api.Persons.AsQueryable()
    where p.Uid == new Guid("70a10bd7-7912-4451-84e8-82ad45408c0c")
    select p;
```

But this query  is still not allowed:
``` C#
var query =
    from p in api.Persons.AsQueryable()
    where p.Uid.ToString() == "70a10bd7-7912-4451-84e8-82ad45408c0c"
    select p;
```
This looks like that you want to call a conversion function on server-side which is not supported. We might be able to implement specific for Guid here a special handling if that is required. Otherwise I would say the user should write more clean code, doing the conversion of string to Guid on client side first e.g. by calling `Guid.Parse("...")` :-)

p.s. I added a special exception `PartialExpressionInvocationFailedException` which is raised when a client side invocation of an expression is not possible. This error returns the expression debug view which should help to identify the issue in the linq expression.

closes #48 