### PR TITLE
throw when ConvertCast fails, improve unit tests

### DIFF
--- a/src/BccCode.Linq/Filter.cs
+++ b/src/BccCode.Linq/Filter.cs
@@ -120,8 +120,18 @@ public class Filter<T> : Filter
                     throw new ArgumentException(
                         $"JSON filter rule is invalid. Value under {key} is not pair.");
                 }
-                deserializedJson[key] = OperandToExpressionResolver.ConvertValue(propertyInfo?.PropertyType ?? GetFilterType(), (array[0].ToString(), array[1].ToString()));
 
+                var propertyType = propertyInfo?.PropertyType ?? GetFilterType();
+                var tupleType = propertyType.IsValueType
+                    ? typeof(ValueTuple<,>).MakeGenericType(propertyType, propertyType)
+                    : typeof(Tuple<,>).MakeGenericType(propertyType, propertyType);
+
+                deserializedJson[key] = Activator.CreateInstance(tupleType,
+                    OperandToExpressionResolver.ConvertValue(propertyInfo?.PropertyType ?? GetFilterType(),
+                        array[0].ToString()),
+                    OperandToExpressionResolver.ConvertValue(propertyInfo?.PropertyType ?? GetFilterType(),
+                        array[1].ToString())
+                );
             }
             else if (key.StartsWith("_"))
             {

--- a/src/BccCode.Linq/FilterInverter.cs
+++ b/src/BccCode.Linq/FilterInverter.cs
@@ -7,8 +7,7 @@ public static class FilterInverter
 {
     public static Filter Invert(Filter filter)
     {
-
-        var inverted = Activator.CreateInstance(filter.GetType(), "{}") as Filter;
+        var inverted = (Filter)Activator.CreateInstance(filter.GetType(), "{}");
 
         foreach (var key in filter.Properties.Keys.ToList())
         {

--- a/tests/BccCode.Linq.Tests/FilterTests.cs
+++ b/tests/BccCode.Linq.Tests/FilterTests.cs
@@ -161,10 +161,11 @@ public class FilterTests
     public void should_not_cast_value_to_date()
     {
         var json = @"{ ""AnyDate"": { ""_eq"": ""2009-gd06-15T13:45:30"" } }";
-        var filter = new Filter<TestClass>(json);
 
-        var value = ((Filter<DateTime>)filter.Properties["AnyDate"]).Properties["_eq"];
-
-        Assert.IsNotType<DateTime>(value);
+        Assert.Throws<InvalidCastException>(() =>
+        {
+            var filter = new Filter<TestClass>(json);
+            var value = ((Filter<DateTime>)filter.Properties["AnyDate"]).Properties["_eq"];
+        });
     }
 }

--- a/tests/BccCode.Linq.Tests/InvertFilterTests.cs
+++ b/tests/BccCode.Linq.Tests/InvertFilterTests.cs
@@ -23,8 +23,8 @@ public class InvertFilterTests
     [Fact]
     public void should_invert_a_logical_filter_operators()
     {
-        var filter = new Filter<TestClass>("{\"_and\":[{\"StrProp\":{\"_eq\":\"this\"}},{\"NumberIntergerProp\":{\"_neq\":\"that\"}}]}");
-        var expected = new Filter<TestClass>("{\"_or\":[{\"StrProp\":{\"_neq\":\"this\"}},{\"NumberIntergerProp\":{\"_eq\":\"that\"}}]}");
+        var filter = new Filter<TestClass>("{\"_and\":[{\"StrProp\":{\"_eq\":\"this\"}},{\"NumberIntergerProp\":{\"_neq\":\"125\"}}]}");
+        var expected = new Filter<TestClass>("{\"_or\":[{\"StrProp\":{\"_neq\":\"this\"}},{\"NumberIntergerProp\":{\"_eq\":\"125\"}}]}");
         var result = filter.GetInvertedFilter();
 
         Assert.True(expected.Properties.Keys.SequenceEqual(result.Properties.Keys));

--- a/tests/BccCode.Linq.Tests/RemoveFieldInFilterTests.cs
+++ b/tests/BccCode.Linq.Tests/RemoveFieldInFilterTests.cs
@@ -19,8 +19,8 @@ public class RemoveFieldFromFilterTests
     {
         var filter =
             new Filter<TestClass>(
-                "{\"Nested\":{\"deeper\":{\"_eq\":\"lorem\"},\"leave\":{\"_eq\":\"x\"}},\"NumberIntergerProp\":{\"_eq\":\"ipsum\"}}");
-        var expected = new Filter<TestClass>("{\"Nested\":{\"leave\":{\"_eq\":\"x\"}},\"NumberIntergerProp\":{\"_eq\":\"ipsum\"}}");
+                "{\"Nested\":{\"deeper\":{\"_eq\":\"lorem\"},\"leave\":{\"_eq\":\"x\"}},\"NumberIntergerProp\":{\"_eq\":\"125\"}}");
+        var expected = new Filter<TestClass>("{\"Nested\":{\"leave\":{\"_eq\":\"x\"}},\"NumberIntergerProp\":{\"_eq\":\"125\"}}");
         filter.RemoveFieldFromFilter("deeper", "Nested");
 
         Assert.True(


### PR DESCRIPTION
This enforces ConvertCast throwing an `InvalidCastException` when cast is not possible. Throw this I found various smaller bugs in unit tests and in the parser which are fixed with this PR as well.