### PR TITLE
add Any/AnyAsync method support

### DIFF
--- a/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
+++ b/src/BccCode.Linq/Async/QueryableAyncExtensions.cs
@@ -1,4 +1,5 @@
-﻿using BccCode.Linq.ApiClient;
+﻿using System.Linq.Expressions;
+using BccCode.Linq.ApiClient;
 
 namespace BccCode.Linq.Async;
 
@@ -81,6 +82,67 @@ public static class QueryableAsyncExtensions
         return list;
     }
 
+    #region Any
+
+    /// <summary>
+    ///     Asynchronously determines whether a sequence contains any elements.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">An <see cref="IQueryable{T}" /> to check for being empty.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation.
+    ///     The task result contains <see langword="true" /> if the source sequence contains any elements; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public static async Task<bool> AnyAsync<TSource>(
+        this IQueryable<TSource> source,
+        CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        var firstOrDefault = await source.FirstOrDefaultAsync(cancellationToken);
+        if (firstOrDefault == null)
+            return false;
+
+        return true;
+    }
+    
+    /// <summary>
+    ///     Asynchronously determines whether any element of a sequence satisfies a condition.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">An <see cref="IQueryable{T}" /> whose elements to test for a condition.</param>
+    /// <param name="predicate">A function to test each element for a condition.</param>
+    /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A task that represents the asynchronous operation.
+    ///     The task result contains <see langword="true" /> if any elements in the source sequence pass the test in the specified
+    ///     predicate; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="source" /> or <paramref name="predicate" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">If the <see cref="CancellationToken" /> is canceled.</exception>
+    public static async Task<bool> AnyAsync<TSource>(
+        this IQueryable<TSource> source,
+        Expression<Func<TSource, bool>> predicate,
+        CancellationToken cancellationToken = default)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        var firstOrDefault = await source.Where(predicate).FirstOrDefaultAsync(cancellationToken);
+        if (firstOrDefault == null)
+            return false;
+
+        return true;
+    }
+
+    #endregion
+    
     #region ElementAt/ElementAtOrDefault
     
     /// <summary>

--- a/src/BccCode.Linq/Extensions/Enumerable.cs
+++ b/src/BccCode.Linq/Extensions/Enumerable.cs
@@ -7,6 +7,13 @@ namespace System.Linq.Internal;
 /// </summary>
 internal static class Enumerable
 {
+    internal static readonly MethodInfo AnyMethodInfo
+        = typeof(System.Linq.Enumerable)
+            .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.Any))
+            .Single(
+                mi => mi.GetGenericArguments().Length == 1
+                      && mi.GetParameters().Length == 1);
+
     internal static readonly MethodInfo FirstMethodInfo
         = typeof(System.Linq.Enumerable)
             .GetTypeInfo().GetDeclaredMethods(nameof(System.Linq.Enumerable.First))

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -4,6 +4,70 @@ namespace BccCode.Linq.Tests;
 
 public class LinqQueryProviderTests
 {
+    #region Any
+
+    [Fact]
+    public void AnyTest()
+    {
+        var api = new ApiClientMockup();
+
+        var anyResult = api.Persons.Any();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Filter);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.True(anyResult);
+    }
+    
+    [Fact]
+    public void AnyPredicateTest()
+    {
+        var api = new ApiClientMockup();
+
+        var anyResult = api.Persons.Any(p => p.Age > 26);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.LastRequest?.Filter);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.True(anyResult);
+    }
+    
+    [Fact]
+    public async void AnyAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var anyResult = await api.Persons.AnyAsync();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Filter);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.True(anyResult);
+    }
+    
+    [Fact]
+    public async void AnyPredicateAsyncTest()
+    {
+        var api = new ApiClientMockup();
+
+        var anyResult = await api.Persons.AnyAsync(p => p.Age > 26);
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.LastRequest?.Filter);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Equal(1, api.LastRequest?.Limit);
+        Assert.True(anyResult);
+    }
+
+    #endregion
+    
     #region ElementAt
 
     [Fact]


### PR DESCRIPTION
Adding support for Linq extension methods:
* `IQueryable.Any()`
* `IQueryable.Any(predicate)`
* `IQueryable.AnyAsync()`
* `IQueryable.AnyAsync(predicate)`