### PR TITLE
disable restriction on selecting a single property

### DIFF
--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -1001,11 +1001,6 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
                             {
                                 Debug.Assert(l.Parameters.Count == 1);
 
-                                if (l.Body is MemberExpression m && (m.Type.IsPrimitive || m.Type == typeof(string)))
-                                {
-                                    throw new Exception($"Selecting '{m.Member.Name}' as a scalar value is not supported due to serialization limitations. Instead, create an anonymous object containing the '{m.Member.Name}' field. e.g. o => new {{ o.{m.Member.Name} }}.");
-                                }
-
                                 _visitMode = VisitLinqLambdaMode.Select;
                                 _activeParameters.Add(l.Parameters[0], apiCaller);
 

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -249,12 +249,13 @@ public class LinqQueryProviderTests
             from p in api.Persons
             select p.Name;
 
-        // Currently not supported
-        Assert.Throws<Exception>(() =>
-        {
-            // ReSharper disable once UnusedVariable
-            var persons = query.ToList();
-        });
+        var persons = query.ToList();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("name", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Equal(5, persons.Count);
     }
 
     [Fact]
@@ -266,12 +267,13 @@ public class LinqQueryProviderTests
             from p in api.Persons
             select p.Age;
 
-        // Currently not supported
-        Assert.Throws<Exception>(() =>
-        {
-            // ReSharper disable once UnusedVariable
-            var persons = query.ToList();
-        });
+        var persons = query.ToList();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("age", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Equal(5, persons.Count);
     }
 
     [Fact]


### PR DESCRIPTION
The restriction that a single property cannot be used in `Select` was added from the original version from bcc-core-api.

This PR is to drop this restriction.
closes #26 

Needs testing against a real API.