### PR TITLE
fix Enumerable.Contains in where clauses

### DIFF
--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -733,7 +733,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
                     case nameof(Enumerable.Contains):
                         {
                             // .Where(p => titles.Contains(p.Title))
-                            if (node.Arguments.Count != 3)
+                            if (node.Arguments.Count != 2)
                             {
                                 throw new NotSupportedException(
                                     $"Unsupported {node.Method.DeclaringType?.FullName}.{node.Method.Name} signature. The method can only be used without comparer.");
@@ -742,11 +742,11 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
                             if (node.Arguments[0] is ConstantExpression c)
                             {
                                 Debug.Assert(_where != null);
-                                _where.Append("{");
+                                _where.Append("{\"");
                                 var arg1 = Visit(node.Arguments[1]);
                                 Debug.Assert(arg1 != null);
                                 Debug.Assert(arg1.NodeType == ExpressionType.Default);
-                                _where.Append(": {\"");
+                                _where.Append("\": {\"");
                                 _where.Append(_inverseOperator ? "_nin" : "_in");
                                 _where.Append("\": [");
 

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -1248,6 +1248,48 @@ public class LinqQueryProviderTests
     #endregion
 
     [Fact]
+    public void WhereContainsInlineGuidArrayTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query =
+            from p in api.Empty
+            where new []{Guid.Empty}.Contains(p.Uuid)
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuid\": {\"_in\": [\"00000000-0000-0000-0000-000000000000\"]}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+
+    [Fact]
+    public void WhereContainsVariableGuidArrayTest()
+    {
+        var api = new ApiClientMockup();
+
+        var uuids = new[] { Guid.Empty };
+
+        var query =
+            from p in api.Empty
+            where uuids.Contains(p.Uuid)
+            select p;
+
+        var persons = query.ToList();
+        Assert.Equal("empty", api.LastEndpoint);
+        Assert.Equal("{\"uuid\": {\"_in\": [\"00000000-0000-0000-0000-000000000000\"]}}", api.LastRequest?.Filter);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Empty(persons);
+    }
+
+    [Fact]
     public void WhereIntGreaterThanTest()
     {
         var api = new ApiClientMockup();


### PR DESCRIPTION
fixes `Enumerable.Contains` inside a where predict expression clause.

Required for https://github.com/bcc-code/bcc-core-api/pull/289 fixing unit test `GetCountry_SelectIn_ReturnsCountry` and `GetCountry_SelectInArray_ReturnsCountry`.