### PR TITLE
add linq Search extension method

### DIFF
--- a/src/BccCode.Linq/QueryProvider/QueryableExtensions.cs
+++ b/src/BccCode.Linq/QueryProvider/QueryableExtensions.cs
@@ -124,4 +124,31 @@ public static class QueryableExtensions
     }
     
     #endregion
+
+    #region Search
+
+    internal static readonly MethodInfo SearchMethodInfo
+        = typeof(QueryableExtensions)
+            .GetTypeInfo().GetDeclaredMethods(nameof(Search))
+            .Single();
+
+    public static IQueryable<TEntity> Search<TEntity>(this IQueryable<TEntity> source, string searchString)
+    {
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        if (source.Provider is ApiQueryProvider)
+        {
+            return source.Provider.CreateQuery<TEntity>(
+                Expression.Call(
+                    instance: null,
+                    method: SearchMethodInfo.MakeGenericMethod(
+                        typeof(TEntity)),
+                    arguments: new []{source.Expression, Expression.Constant(searchString)}));
+        }
+ 
+        throw new NotSupportedException("Linq method Search was not replaced by the queryable provider. You can only use this method with a IQueryable<> object from an Bcc Code API. If you already use a IQueryable<> object from a Bcc Code API, try to call Search earlier in your Linq command chain.");
+    }
+
+    #endregion
 }

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -1,4 +1,5 @@
-﻿using BccCode.Linq.Async;
+﻿using System.Text;
+using BccCode.Linq.Async;
 
 namespace BccCode.Linq.Tests;
 
@@ -280,6 +281,49 @@ public class LinqQueryProviderTests
         Assert.Null(api.LastRequest?.Offset);
         Assert.Equal(1, api.LastRequest?.Limit);
         Assert.Null(testClass);
+    }
+
+    #endregion
+
+    #region Search
+
+    [Fact]
+    public void SearchConstantTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Persons.Search("Chuck Norris");
+
+        var persons = query.ToList();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Equal("Chuck Norris", api.LastRequest?.Search);
+        Assert.Equal(5, persons.Count);
+    }
+    
+    [Fact]
+    public void SearchStringBuilderTest()
+    {
+        var api = new ApiClientMockup();
+
+        var sb = new StringBuilder();
+        sb.Append("Chuck");
+        sb.Append(' ');
+        sb.Append("Norris");
+
+        var query = api.Persons.Search(sb.ToString());
+
+        var persons = query.ToList();
+        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("*", api.LastRequest?.Fields);
+        Assert.Null(api.LastRequest?.Sort);
+        Assert.Null(api.LastRequest?.Offset);
+        Assert.Null(api.LastRequest?.Limit);
+        Assert.Equal("Chuck Norris", api.LastRequest?.Search);
+        Assert.Equal(5, persons.Count);
     }
 
     #endregion


### PR DESCRIPTION
Add linq extension method `Search`

resolves https://github.com/bcc-code/bcc-core-api/issues/365