### PR TITLE
fix passing metadata to IResultList<T> in ApiPagedEnumerable.FetchAsync

### DIFF
--- a/src/BccCode.Linq/ApiClient/ApiPagedEnumerable.cs
+++ b/src/BccCode.Linq/ApiClient/ApiPagedEnumerable.cs
@@ -82,7 +82,7 @@ internal class ApiPagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IApi
         int page = 1;
         do
         {
-            pageData = await RequestPageAsync(page++, cancellationToken);
+            pageData = await RequestPageAsync(page, cancellationToken);
             if (pageData == null)
                 break;
 
@@ -92,6 +92,8 @@ internal class ApiPagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IApi
             }
             
             resultList.Data.AddRange(pageData.Data);
+
+            page++;
         } while (pageData.Data.Count == RowsPerPage);
 
         if (resultList.Data.Count == 0)


### PR DESCRIPTION
This PR should fix the issue of not getting metadata when using method `ApiPagedEnumerable.FetchAsync`