### PR TITLE
Refactor paged requests

### DIFF
--- a/src/BccCode.Linq/ApiClient/IQueryableApiClient.cs
+++ b/src/BccCode.Linq/ApiClient/IQueryableApiClient.cs
@@ -3,6 +3,11 @@
 public interface IQueryableApiClient
 {
     /// <summary>
+    /// Number of rows to request from server when making paged requests.
+    /// </summary>
+    int? QueryBatchSize { get; }
+
+    /// <summary>
     /// Creates an API request instance for a specific API endpoint
     /// which must implement <see cref="IQueryableApiClient"/>. 
     /// </summary>

--- a/src/BccCode.Linq/ApiClient/IQueryableParameters.cs
+++ b/src/BccCode.Linq/ApiClient/IQueryableParameters.cs
@@ -129,4 +129,6 @@ public interface IQueryableParameters
     /// <b>Filter Count (<c>filter_count</c>)</b>
     /// </summary>
     public string? Meta { get; set; }
+
+    public IQueryableParameters Clone();
 }

--- a/src/BccCode.Linq/ApiClient/IQueryableParametersExtensions.cs
+++ b/src/BccCode.Linq/ApiClient/IQueryableParametersExtensions.cs
@@ -40,6 +40,7 @@ namespace BccCode.Linq.ApiClient
 
             return string.Join('&', urlParameters.Select(p => $"{p.Key}={WebUtility.UrlEncode(p.Value)}"));            
         }
+                
 
     }
 }

--- a/src/BccCode.Linq/ApiClient/QueryablePagedEnumerable.cs
+++ b/src/BccCode.Linq/ApiClient/QueryablePagedEnumerable.cs
@@ -94,6 +94,7 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
             if (hasLimit && !usePaging && initialLimit!.Value < (totalRequested + pageSize))
             {
                 pageSize = initialLimit!.Value - totalRequested;
+                QueryParameters.Limit = pageSize;
             }
             pageData = await RequestPageAsync(cancellationToken);            
             if (pageData == null)
@@ -146,6 +147,7 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
             if (hasLimit && !usePaging && initialLimit!.Value < (totalRequested + pageSize))
             {
                 pageSize = initialLimit!.Value - totalRequested;
+                QueryParameters.Limit = pageSize;
             }
             pageData = await RequestPageAsync(cancellationToken);
             if (pageData?.Data == null)
@@ -190,6 +192,7 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
             if (hasLimit && !usePaging && initialLimit!.Value < (totalRequested + pageSize))
             {
                 pageSize = initialLimit!.Value - totalRequested;
+                QueryParameters.Limit = pageSize;
             }
             pageData = RequestPage();
             if (pageData?.Data == null)

--- a/src/BccCode.Linq/ApiClient/QueryablePagedEnumerable.cs
+++ b/src/BccCode.Linq/ApiClient/QueryablePagedEnumerable.cs
@@ -17,7 +17,7 @@ internal interface IApiCaller : IEnumerable
 /// A class returning data from the API by requesting data per page. 
 /// </summary>
 /// <typeparam name="T"></typeparam>
-internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IApiCaller
+internal partial class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>, IApiCaller
 {
     /// <summary>
     /// The maximum number of rows per page allowed by the API.
@@ -27,21 +27,21 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
 
     private readonly IQueryableApiClient _apiClient;
     private readonly string _path;
-    private int _rowsPerPage = 100;
+    private int _queryBatchSize = 100;
 
     /// <summary>
     /// Set the number of data models to be retrieved per API call. 
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-    public int RowsPerPage
+    public int QueryBatchSize
     {
-        get => _rowsPerPage;
+        get => _queryBatchSize;
         set
         {
             if (value <= 0 || value > MaxRowsPerPage)
                 throw new ArgumentOutOfRangeException($"The rows per page can be between 1 and {MaxRowsPerPage}");
 
-            _rowsPerPage = value;
+            _queryBatchSize = value;
         }
     }
 
@@ -54,71 +54,42 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
     {
         _apiClient = apiClient;
         _path = path;
+        QueryBatchSize = apiClient.QueryBatchSize ?? QueryBatchSize;
         QueryParameters = apiClient.ConstructQueryableParameters(_path);
         parametersCallback?.Invoke(QueryParameters);        
     }
 
-    private ResultList<T>? RequestPage()
+    private ResultList<T>? RequestPage(IQueryableParameters parameters)
     {
-        return _apiClient.Query<ResultList<T>>(_path, QueryParameters);
+        return _apiClient.Query<ResultList<T>>(_path, parameters);
     }
 
-    private Task<ResultList<T>?> RequestPageAsync(CancellationToken cancellationToken = default)
+    private Task<ResultList<T>?> RequestPageAsync(IQueryableParameters parameters, CancellationToken cancellationToken = default)
     {
-        return _apiClient.QueryAsync<ResultList<T>>(_path, QueryParameters, cancellationToken);
+        return _apiClient.QueryAsync<ResultList<T>>(_path, parameters, cancellationToken);
     }
 
+    
     public async Task<IResultList<T>?> FetchAsync(CancellationToken cancellationToken = default)
     {
         var resultList = new ResultList<T>();
         resultList.Data = new List<T>();
         ResultList<T>? pageData;
-        int? initialLimit = QueryParameters.Limit;
-        int? initialOffset = QueryParameters.Offset;
-        int? initialPage = QueryParameters.Page;
-        var hasLimit = initialLimit.HasValue && initialLimit > 0;
-        var usePaging = initialPage.HasValue && initialPage > 0;
-
-        int pageSize = usePaging && hasLimit ? initialLimit!.Value : 
-                       (hasLimit && initialLimit!.Value < RowsPerPage ? initialLimit!.Value : RowsPerPage);
-        int offset = usePaging ? (initialPage!.Value-1) * pageSize : (initialOffset ?? 0);
-
-        // Modify query paramter values for paging
-        QueryParameters.Page = null;
-        QueryParameters.Offset = offset > 0 ? offset : null;
-        QueryParameters.Limit = pageSize;
-        
-        int totalRequested = 0;      
+        var state = QueryablePagedEnumerableState.Create(QueryParameters, QueryBatchSize);         
         do
         {
-            if (hasLimit && !usePaging && initialLimit!.Value < (totalRequested + pageSize))
-            {
-                pageSize = initialLimit!.Value - totalRequested;
-                QueryParameters.Limit = pageSize;
-            }
-            pageData = await RequestPageAsync(cancellationToken);            
+            pageData = await RequestPageAsync(state.PageParameters, cancellationToken);            
             if (pageData == null)
                 break;
 
-            if (totalRequested == 0) //First page
+            if (state.TotalRequested == 0) //First page
             {
                 resultList.Meta = new Metadata(pageData.Meta);
             }
 
             resultList.AddData(pageData.Data);
 
-            QueryParameters.Offset = (QueryParameters.Offset ?? 0) + pageSize;
-            totalRequested += pageSize;
-        } while ((pageData.Data?.Count ?? 0) == pageSize && (!hasLimit || totalRequested < initialLimit!.Value));
-
-        // Restore query paramter values
-        QueryParameters.Page = initialPage;
-        QueryParameters.Offset = initialOffset;
-        QueryParameters.Limit = initialLimit;
-
-        if (resultList.Data.Count == 0)
-            return null;
-
+        } while (state.NextPage(pageData.Data?.Count ?? 0));
 
         return resultList.ToImmutableResultList();
     }
@@ -126,30 +97,10 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
     public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
     {
         ResultList<T>? pageData;
-        int? initialLimit = QueryParameters.Limit;
-        int? initialOffset = QueryParameters.Offset;
-        int? initialPage = QueryParameters.Page;
-        var hasLimit = initialLimit.HasValue && initialLimit > 0;
-        var usePaging = initialPage.HasValue && initialPage > 0;
-
-        int pageSize = usePaging && hasLimit ? initialLimit!.Value :
-                       (hasLimit && initialLimit!.Value < RowsPerPage ? initialLimit!.Value : RowsPerPage);
-        int offset = usePaging ? (initialPage!.Value - 1) * pageSize : (initialOffset ?? 0);
-
-        // Modify query paramter values for paging
-        QueryParameters.Page = null;
-        QueryParameters.Offset = offset > 0 ? offset : null;
-        QueryParameters.Limit = pageSize;
-
-        int totalRequested = 0;
+        var state = QueryablePagedEnumerableState.Create(QueryParameters, QueryBatchSize);
         do
         {
-            if (hasLimit && !usePaging && initialLimit!.Value < (totalRequested + pageSize))
-            {
-                pageSize = initialLimit!.Value - totalRequested;
-                QueryParameters.Limit = pageSize;
-            }
-            pageData = await RequestPageAsync(cancellationToken);
+            pageData = await RequestPageAsync(state.PageParameters, cancellationToken);
             if (pageData?.Data == null)
                 yield break;
 
@@ -158,43 +109,16 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
                 yield return row;
             }
 
-            QueryParameters.Offset = (QueryParameters.Offset ?? 0) + pageSize;
-            totalRequested += pageSize;
-        } while ((pageData.Data?.Count ?? 0) == pageSize && (!hasLimit || totalRequested < initialLimit!.Value));
-
-        // Restore query paramter values
-        QueryParameters.Page = initialPage;
-        QueryParameters.Offset = initialOffset;
-        QueryParameters.Limit = initialLimit;
+        } while (state.NextPage(pageData.Data?.Count ?? 0));
     }
 
     public IEnumerator<T> GetEnumerator()
     {
         ResultList<T>? pageData;
-        int? initialLimit = QueryParameters.Limit;
-        int? initialOffset = QueryParameters.Offset;
-        int? initialPage = QueryParameters.Page;
-        var hasLimit = initialLimit.HasValue && initialLimit > 0;
-        var usePaging = initialPage.HasValue && initialPage > 0;
-
-        int pageSize = usePaging && hasLimit ? initialLimit!.Value :
-                       (hasLimit && initialLimit!.Value < RowsPerPage ? initialLimit!.Value : RowsPerPage);
-        int offset = usePaging ? (initialPage!.Value - 1) * pageSize : (initialOffset ?? 0);
-
-        // Modify query paramter values for paging
-        QueryParameters.Page = null;
-        QueryParameters.Offset = offset > 0 ? offset : null;
-        QueryParameters.Limit = pageSize;
-
-        int totalRequested = 0;
+        var state = QueryablePagedEnumerableState.Create(QueryParameters, QueryBatchSize);
         do
         {
-            if (hasLimit && !usePaging && initialLimit!.Value < (totalRequested + pageSize))
-            {
-                pageSize = initialLimit!.Value - totalRequested;
-                QueryParameters.Limit = pageSize;
-            }
-            pageData = RequestPage();
+            pageData = RequestPage(state.PageParameters);
             if (pageData?.Data == null)
                 yield break;
 
@@ -203,14 +127,7 @@ internal class QueryablePagedEnumerable<T> : IEnumerable<T>, IAsyncEnumerable<T>
                 yield return row;
             }
 
-            QueryParameters.Offset = (QueryParameters.Offset ?? 0) + pageSize;
-            totalRequested += pageSize;
-        } while ((pageData.Data?.Count ?? 0) == pageSize && (!hasLimit || totalRequested < initialLimit!.Value));
-
-        // Restore query paramter values
-        QueryParameters.Page = initialPage;
-        QueryParameters.Offset = initialOffset;
-        QueryParameters.Limit = initialLimit;
+        } while (state.NextPage(pageData.Data?.Count ?? 0));
     }
 
     #region IEnumerator

--- a/src/BccCode.Linq/ApiClient/QueryablePagedEnumerableState.cs
+++ b/src/BccCode.Linq/ApiClient/QueryablePagedEnumerableState.cs
@@ -1,0 +1,106 @@
+﻿namespace BccCode.Linq.ApiClient;
+
+
+public class QueryablePagedEnumerableState
+{
+    private QueryablePagedEnumerableState() { PageParameters = new QueryableParameters(); ClientParameters = new QueryableParameters(); }
+
+    private QueryablePagedEnumerableState(IQueryableParameters parameters, int queryBatchSize) {
+        ClientParameters = parameters;
+        PageParameters = parameters.Clone();
+        QueryBatchSize = queryBatchSize;
+    }
+    public static QueryablePagedEnumerableState Create(IQueryableParameters clientParams, int queryBatchSize)
+    {
+        var s = new QueryablePagedEnumerableState(clientParams, queryBatchSize);
+
+        // Set total limit to Limit provided by client
+        s.TotalLimit = clientParams.Limit;
+
+        // Calculate Offset if Page has been specified instead of Offset
+        if (clientParams.Page.HasValue && clientParams.Page > 0)
+        {
+            // If Page is specified by the client, we only want to request one page.
+            s.TotalLimit = (clientParams.Limit ?? s.QueryBatchSize);
+                    
+            // Calculate offset from Page and Limit
+            var offset = (clientParams.Page.Value - 1) * s.TotalLimit;
+
+            // Validation: Check if offset has been set to something other than offset calculated from Page
+            if (clientParams.Offset.HasValue && clientParams.Offset > 0 && clientParams.Offset.Value != offset)
+            {
+                throw new Exception("Offset and Page parameters cannot be used simultaneously. If Page is set, offset will be calculated using the formula Offset=(Page-1)*Limit.");
+            }
+
+            //Set Offset instead of Page
+            s.PageParameters.Offset = offset;
+        }
+        //Don't use Page parameter for server requests
+        s.PageParameters.Page = null;
+        s.InitialOffset = s.PageParameters.Offset ?? 0;
+        s.PageSize = s.Unlimited ? s.QueryBatchSize : Math.Min(s.TotalLimit!.Value, s.QueryBatchSize);
+        s.PageParameters.Limit = s.PageSize;
+        s.NextPage(0);
+        return s;
+    }
+
+    public int QueryBatchSize { get; }
+
+    public bool Unlimited => !TotalLimit.HasValue || TotalLimit == 0;
+
+    public int? TotalLimit { get; private set; }
+
+    public int InitialOffset { get; private set; }
+
+    public int TotalRequested { get; private set; }
+
+    public int PageSize { get; private set; }
+
+    public IQueryableParameters ClientParameters { get; }
+
+    public IQueryableParameters PageParameters { get;  }
+
+    public bool NextPage(int previousResultCount)
+    {
+        TotalRequested += previousResultCount;
+
+
+
+
+        PageParameters.Offset = InitialOffset + TotalRequested;
+
+        //Avoid sending redundant parameter
+        if (PageParameters.Offset == 0)
+        {
+            PageParameters.Offset = null;
+        }
+
+        PageSize = GetNextPageSize();
+        PageParameters.Limit = PageSize;
+
+
+        if (previousResultCount < PageSize)
+        {
+            return false;
+        }
+        if (!Unlimited && TotalRequested >= TotalLimit)
+        {
+            return false;
+        }
+
+
+        return true;
+    }
+
+    private int GetNextPageSize() 
+    {
+        if (!Unlimited && TotalLimit < (TotalRequested + PageSize))
+        {
+            return TotalLimit!.Value - TotalRequested;
+        }
+        return PageSize;
+    }
+    
+
+}
+

--- a/src/BccCode.Linq/ApiClient/QueryableParameters.cs
+++ b/src/BccCode.Linq/ApiClient/QueryableParameters.cs
@@ -60,6 +60,7 @@ namespace BccCode.Linq.ApiClient
         [FromQuery(Name = "page")]
         public int? Page { get; set; }
 
+
         /// <summary>
         /// Aggregate functions allow you to perform calculations on a set of values, returning a single result.
         /// 
@@ -149,6 +150,8 @@ namespace BccCode.Linq.ApiClient
         /// </summary>
         [FromQuery(Name = "meta")]
         public string? Meta { get; set; }
+
+        public virtual IQueryableParameters Clone() => (QueryableParameters)MemberwiseClone();
 
     }
 }

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -959,7 +959,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
                         if (c.Type != typeof(int))
                             throw new NotSupportedException(
                                 "The parameter for Queryable.ElementAt/ElementAtOrDefault must be a constant integer expression");
-                        apiCaller.QueryParameters.Offset = (int)c.Value;
+                        apiCaller.QueryParameters.Offset = (int)c.Value > 0 ? (int)c.Value : null;
                         apiCaller.QueryParameters.Limit = 1;
 
                         // We remove here the Take method call from the expression tree,

--- a/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/QueryProvider/ApiQueryProvider.cs
@@ -114,7 +114,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
     /// The URL path passed to the API client on request.
     /// </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public ApiQueryProvider(IQueryableApiClient apiClient, string path = "", Action<IQueryableParameters>? parametersCallback = null)
+    public ApiQueryProvider(IQueryableApiClient apiClient, string path = "", Action<IQueryableParameters>? parametersCallback = default(Action<IQueryableParameters>))
     {
         _apiClient = apiClient ?? throw new ArgumentNullException(nameof(apiClient));
         _path = path;

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -13,12 +13,12 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var anyResult = api.Persons.Any();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.True(anyResult);
     }
     
@@ -28,12 +28,12 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var anyResult = api.Persons.Any(p => p.Age > 26);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.LastRequestQuery?.Filter);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.ClientQuery?.Filter);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.True(anyResult);
     }
     
@@ -43,12 +43,12 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var anyResult = await api.Persons.AnyAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.True(anyResult);
     }
     
@@ -58,12 +58,12 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var anyResult = await api.Persons.AnyAsync(p => p.Age > 26);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.LastRequestQuery?.Filter);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.ClientQuery?.Filter);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.True(anyResult);
     }
 
@@ -77,11 +77,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = api.Persons.ElementAt(2);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(2, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(2, api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
         //       from the expression tree, the result will be still the first element of the mockup data.
         //Assert.Equal("Chelsey Logan", persons.Name);
@@ -94,11 +94,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = await api.Persons.ElementAtAsync(2);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(2, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(2, api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
         //       from the expression tree, the result will be still the first element of the mockup data.
         //Assert.Equal("Chelsey Logan", persons.Name);
@@ -115,11 +115,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = api.Persons.ElementAtOrDefault(2);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(2, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(2, api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
         //       from the expression tree, the result will be still the first element of the mockup data.
         //Assert.Equal("Chelsey Logan", persons.Name);
@@ -132,11 +132,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = await api.Persons.ElementAtOrDefaultAsync(2);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(2, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(2, api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
         //       from the expression tree, the result will be still the first element of the mockup data.
         //Assert.Equal("Chelsey Logan", persons.Name);
@@ -149,11 +149,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = api.Persons.ElementAtOrDefault(int.MaxValue);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(int.MaxValue, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(int.MaxValue, api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
         //       from the expression tree, the result will be still the first element of the mockup data.
         //Assert.Equal(null, persons.Name);
@@ -166,11 +166,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var testClass = api.Empty.ElementAtOrDefault(0);
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(0, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Null(testClass);
     }
     
@@ -180,11 +180,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = await api.Persons.ElementAtOrDefaultAsync(int.MaxValue);
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(int.MaxValue, api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(int.MaxValue, api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret ElementAt clauses. Since we remove the ElementAt clause
         //       from the expression tree, the result will be still the first element of the mockup data.
         //Assert.Equal(null, persons.Name);
@@ -201,11 +201,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = api.Persons.First();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Equal("Archibald Mcbride", persons.Name);
     }
     
@@ -215,11 +215,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = await api.Persons.FirstAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Equal("Archibald Mcbride", persons.Name);
     }
 
@@ -233,11 +233,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = api.Persons.FirstOrDefault();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Equal("Archibald Mcbride", persons?.Name);
     }
     
@@ -247,11 +247,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var testClass = api.Empty.FirstOrDefault();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Null(testClass);
     }
     
@@ -261,11 +261,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var persons = await api.Persons.FirstOrDefaultAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Equal("Archibald Mcbride", persons?.Name);
     }
     
@@ -275,11 +275,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var testClass = await api.Empty.FirstOrDefaultAsync();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.Null(testClass);
     }
 
@@ -295,12 +295,12 @@ public class LinqQueryProviderTests
         var query = api.Persons.Search("Chuck Norris");
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
-        Assert.Equal("Chuck Norris", api.LastRequestQuery?.Search);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
+        Assert.Equal("Chuck Norris", api.ClientQuery?.Search);
         Assert.Equal(5, persons.Count);
     }
     
@@ -317,12 +317,12 @@ public class LinqQueryProviderTests
         var query = api.Persons.Search(sb.ToString());
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
-        Assert.Equal("Chuck Norris", api.LastRequestQuery?.Search);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
+        Assert.Equal("Chuck Norris", api.ClientQuery?.Search);
         Assert.Equal(5, persons.Count);
     }
 
@@ -340,11 +340,11 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -358,11 +358,11 @@ public class LinqQueryProviderTests
             select p.Name;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("name", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("name", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -376,11 +376,11 @@ public class LinqQueryProviderTests
             select p.Age;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("age", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("age", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -397,11 +397,11 @@ public class LinqQueryProviderTests
             };
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("name", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("name", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -418,11 +418,11 @@ public class LinqQueryProviderTests
             };
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("car,car.manufacturer", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("car,car.manufacturer", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -440,11 +440,11 @@ public class LinqQueryProviderTests
             };
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("name,age", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("name,age", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -462,11 +462,11 @@ public class LinqQueryProviderTests
             // ReSharper disable once UnusedVariable
             var persons = api.Persons.Single();
         });
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(2, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(2, api.ClientQuery?.Limit);
     }
     
     [Fact]
@@ -479,11 +479,11 @@ public class LinqQueryProviderTests
             // ReSharper disable once UnusedVariable
             var persons = await api.Persons.SingleAsync();
         });
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(2, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(2, api.ClientQuery?.Limit);
     }
 
     #endregion
@@ -499,11 +499,11 @@ public class LinqQueryProviderTests
             // ReSharper disable once UnusedVariable
             var persons = api.Persons.SingleOrDefault();
         });
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(2, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(2, api.ClientQuery?.Limit);
     }
     
     [Fact]
@@ -512,11 +512,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var testClass = api.Empty.SingleOrDefault();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(2, api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(2, api.ClientQuery?.Limit);
         Assert.Null(testClass);
     }
     
@@ -530,11 +530,11 @@ public class LinqQueryProviderTests
             // ReSharper disable once UnusedVariable
             var persons = await api.Persons.SingleOrDefaultAsync();
         });
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(2, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(2, api.ClientQuery?.Limit);
     }
     
     [Fact]
@@ -543,11 +543,11 @@ public class LinqQueryProviderTests
         var api = new ApiClientMockup();
 
         var testClass = await api.Empty.SingleOrDefaultAsync();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(2, api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(2, api.ClientQuery?.Limit);
         Assert.Null(testClass);
     }
     
@@ -569,12 +569,12 @@ public class LinqQueryProviderTests
             select m;
 
         var manufacturer = query.FirstOrDefault();
-        Assert.Equal("manufacturers", api.LastEndpoint);
-        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("manufacturers", api.PageEndpoint);
+        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.NotNull(manufacturer);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the first row of the mockup data.
@@ -594,12 +594,12 @@ public class LinqQueryProviderTests
             select m;
 
         var manufacturer = query.FirstOrDefault();
-        Assert.Equal("manufacturers", api.LastEndpoint);
-        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("manufacturers", api.PageEndpoint);
+        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.NotNull(manufacturer);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the first row of the mockup data.
@@ -621,12 +621,12 @@ public class LinqQueryProviderTests
             select m;
 
         var manufacturer = query.FirstOrDefault();
-        Assert.Equal("manufacturers", api.LastEndpoint);
-        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("manufacturers", api.PageEndpoint);
+        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.NotNull(manufacturer);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the first row of the mockup data.
@@ -647,12 +647,12 @@ public class LinqQueryProviderTests
             select m;
 
         var manufacturer = query.FirstOrDefault();
-        Assert.Equal("manufacturers", api.LastEndpoint);
-        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(1, api.LastRequestQuery?.Limit);
+        Assert.Equal("manufacturers", api.PageEndpoint);
+        Assert.Equal("{\"uid\": {\"_eq\": \"16b41e40-ee3c-4837-b9a9-57b76c7d1d9d\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(1, api.ClientQuery?.Limit);
         Assert.NotNull(manufacturer);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the first row of the mockup data.
@@ -670,12 +670,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"strProp\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -690,12 +690,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"strProp\": {\"_eq\": \"\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": \"\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -710,12 +710,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"numberIntergerProp\": {\"_eq\": 5}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"numberIntergerProp\": {\"_eq\": 5}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -730,12 +730,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"intNullable\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"intNullable\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -750,12 +750,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"intNullable\": {\"_eq\": 5}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"intNullable\": {\"_eq\": 5}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -771,12 +771,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"numberDoubleProp\": {\"_eq\": -5.13}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"numberDoubleProp\": {\"_eq\": -5.13}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -791,12 +791,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"numberLongProp\": {\"_eq\": 3372036854775807}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"numberLongProp\": {\"_eq\": 3372036854775807}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -811,12 +811,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"booleanProp\": {\"_eq\": true}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"booleanProp\": {\"_eq\": true}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -831,12 +831,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"amount\": {\"_eq\": 312312.5434353}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"amount\": {\"_eq\": 312312.5434353}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -851,12 +851,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"amountNullable\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"amountNullable\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -871,12 +871,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"amountNullable\": {\"_eq\": 312312.5434353}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"amountNullable\": {\"_eq\": 312312.5434353}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -891,12 +891,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"anyDate\": {\"_eq\": \"2013-12-04T04:02:05.0000000Z\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2013-12-04T04:02:05.0000000Z\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -911,12 +911,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateNullable\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -931,12 +931,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2013-12-04T04:02:05.0000000Z\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2013-12-04T04:02:05.0000000Z\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -952,12 +952,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2013-12-04\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2013-12-04\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 #endif
@@ -973,12 +973,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuid\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuid\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -993,12 +993,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuidNullable\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1013,12 +1013,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuidNullable\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 
@@ -1037,12 +1037,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"strProp\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1057,12 +1057,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"strProp\": {\"_eq\": \"\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"strProp\": {\"_eq\": \"\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1224,12 +1224,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"anyDate\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1244,12 +1244,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateNullable\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1264,12 +1264,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"dateNullable\": {\"_eq\": \"2023-12-04T04:02:05Z\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1285,12 +1285,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-04\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"dateOnly\": {\"_eq\": \"2023-12-04\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 #endif
@@ -1306,12 +1306,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuid\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuid\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 
@@ -1326,12 +1326,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuidNullable\": {\"_eq\": null}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": null}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
     
@@ -1346,12 +1346,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuidNullable\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuidNullable\": {\"_eq\": \"00000000-0000-0000-0000-000000000000\"}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 
@@ -1368,12 +1368,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuid\": {\"_in\": [\"00000000-0000-0000-0000-000000000000\"]}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuid\": {\"_in\": [\"00000000-0000-0000-0000-000000000000\"]}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 
@@ -1390,12 +1390,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("empty", api.LastEndpoint);
-        Assert.Equal("{\"uuid\": {\"_in\": [\"00000000-0000-0000-0000-000000000000\"]}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Equal("{\"uuid\": {\"_in\": [\"00000000-0000-0000-0000-000000000000\"]}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Empty(persons);
     }
 
@@ -1410,12 +1410,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(2, persons.Count);
@@ -1433,10 +1433,10 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("{\"age\": {\"_gt\": 26}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(2, persons.Count);
@@ -1454,12 +1454,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("{\"age\": {\"_lte\": 26}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("{\"age\": {\"_lte\": 26}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(2, persons.Count);
@@ -1477,10 +1477,10 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Equal("{\"age\": {\"_lte\": 26}}", api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Equal("{\"age\": {\"_lte\": 26}}", api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(2, persons.Count);
@@ -1501,13 +1501,13 @@ public class LinqQueryProviderTests
             };
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal("{\"_and\": [{\"age\": {\"_gt\": 26}}, {\"name\": {\"_eq\": \"Reid Cantrell\"}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("country", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("country", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(1, persons.Count);
@@ -1528,11 +1528,11 @@ public class LinqQueryProviderTests
             };
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal("{\"_and\": [{\"age\": {\"_gt\": 26}}, {\"name\": {\"_eq\": \"Reid Cantrell\"}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("country", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("country", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
 
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
@@ -1555,13 +1555,13 @@ public class LinqQueryProviderTests
             };
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal("{\"_or\": [{\"age\": {\"_gt\": 26}}, {\"name\": {\"_eq\": \"Chelsey Logan\"}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("country,name", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("country,name", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -1583,11 +1583,11 @@ public class LinqQueryProviderTests
             };
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal("{\"_or\": [{\"age\": {\"_gt\": 26}}, {\"name\": {\"_eq\": \"Chelsey Logan\"}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("country,name", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("country,name", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -1609,14 +1609,14 @@ public class LinqQueryProviderTests
             };
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"_or\": [{\"_or\": [{\"age\": {\"_gt\": 26}}, {\"name\": {\"_eq\": \"Chelsey Logan\"}}]}, {\"country\": {\"_eq\": \"US\"}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("country,name", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("country,name", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(4, persons.Count);
@@ -1638,12 +1638,12 @@ public class LinqQueryProviderTests
             };
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"_or\": [{\"_or\": [{\"age\": {\"_gt\": 26}}, {\"name\": {\"_eq\": \"Chelsey Logan\"}}]}, {\"country\": {\"_eq\": \"US\"}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("country,name", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("country,name", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(4, persons.Count);
@@ -1661,14 +1661,14 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"name\": {\"_starts_with\": \"Chelsey\"}}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(1, persons.Count);
@@ -1686,12 +1686,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"name\": {\"_starts_with\": \"Chelsey\"}}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(1, persons.Count);
@@ -1709,14 +1709,14 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"name\": {\"_ends_with\": \"Cantrell\"}}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(1, persons.Count);
@@ -1734,12 +1734,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"name\": {\"_ends_with\": \"Cantrell\"}}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(1, persons.Count);
@@ -1757,14 +1757,14 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"name\": {\"_empty\": null}}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(0, persons.Count);
@@ -1782,12 +1782,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"name\": {\"_empty\": null}}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(0, persons.Count);
@@ -1805,14 +1805,14 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"_and\": [{\"car\": {\"_neq\": null}}, {\"car\": {\"model\": {\"_eq\": \"Opel\"}}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(2, persons.Count);
@@ -1830,12 +1830,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
+        Assert.Equal("persons", api.PageEndpoint);
         Assert.Equal(
             "{\"_and\": [{\"car\": {\"_neq\": null}}, {\"car\": {\"model\": {\"_eq\": \"Opel\"}}}]}",
-            api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
+            api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
         // NOTE: Currently the Mockup API Client does not interpret Where clauses. Since we remove the Where clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(2, persons.Count);
@@ -1857,12 +1857,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("name", api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("name", api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1877,10 +1877,10 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("name", api.LastRequestQuery?.Sort);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("name", api.ClientQuery?.Sort);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1895,12 +1895,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("-name", api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("-name", api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1915,10 +1915,10 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("-name", api.LastRequestQuery?.Sort);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("-name", api.ClientQuery?.Sort);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1933,12 +1933,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("name,-age,country", api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("name,-age,country", api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1953,10 +1953,10 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("name,-age,country", api.LastRequestQuery?.Sort);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("name,-age,country", api.ClientQuery?.Sort);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1971,12 +1971,12 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("car.manufacturer", api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("car.manufacturer", api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         Assert.Equal(5, persons.Count);
     }
 
@@ -1992,12 +1992,12 @@ public class LinqQueryProviderTests
         var query = api.Persons.Skip(2);
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(2, api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(2, api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -2016,12 +2016,12 @@ public class LinqQueryProviderTests
         var query = api.Persons.Take(3);
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Equal(3, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Equal(3, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -2036,12 +2036,12 @@ public class LinqQueryProviderTests
         var query = api.Persons.Skip(2).Take(3);
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Equal(2, api.LastRequestQuery?.Offset);
-        Assert.Equal(3, api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Equal(2, api.ClientQuery?.Offset);
+        Assert.Equal(3, api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -2059,10 +2059,10 @@ public class LinqQueryProviderTests
             select p;
 
         var persons = await query.ToListAsync();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*", api.LastRequestQuery?.Fields);
-        Assert.Equal("car.manufacturer", api.LastRequestQuery?.Sort);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*", api.ClientQuery?.Fields);
+        Assert.Equal("car.manufacturer", api.ClientQuery?.Sort);
         Assert.Equal(5, persons.Count);
     }
 
@@ -2079,12 +2079,12 @@ public class LinqQueryProviderTests
             .Include(p => p.Car);
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*,car.*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*,car.*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -2100,12 +2100,12 @@ public class LinqQueryProviderTests
             .Include(p => p.Car.Manufacturer);
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*,car.manufacturer.*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*,car.manufacturer.*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);
@@ -2122,12 +2122,12 @@ public class LinqQueryProviderTests
                 .ThenInclude(c => c.ManufacturerInfo);
 
         var persons = query.ToList();
-        Assert.Equal("persons", api.LastEndpoint);
-        Assert.Null(api.LastRequestQuery?.Filter);
-        Assert.Equal("*,car.*,car.manufacturerInfo.*", api.LastRequestQuery?.Fields);
-        Assert.Null(api.LastRequestQuery?.Sort);
-        Assert.Null(api.LastRequestQuery?.Offset);
-        Assert.Null(api.LastRequestQuery?.Limit);
+        Assert.Equal("persons", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*,car.*,car.manufacturerInfo.*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
         // NOTE: Currently the Mockup API Client does not interpret Take clauses. Since we remove the Take clause
         //       from the expression tree, the result will be still the total count of the mockup data.
         //Assert.Equal(3, persons.Count);

--- a/tests/BccCode.Linq.Tests/Mockups/ApiClientMockup.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiClientMockup.cs
@@ -14,7 +14,7 @@ public class ApiClientMockup : ApiClientMockupBase
     }
 
     // strongly typed entities
-    public IQueryable<Person> Persons => this.GetQueryable<Person>("persons");
-    public IQueryable<TestClass> Empty => this.GetQueryable<TestClass>("empty");
-    public IQueryable<ManufacturerInfo> Manufacturers => this.GetQueryable<ManufacturerInfo>("manufacturers");
+    public IQueryable<Person> Persons => this.GetQueryable<Person>("persons", a => this.ClientQuery = a);
+    public IQueryable<TestClass> Empty => this.GetQueryable<TestClass>("empty", a => this.ClientQuery = a);
+    public IQueryable<ManufacturerInfo> Manufacturers => this.GetQueryable<ManufacturerInfo>("manufacturers", a => this.ClientQuery = a);
 }

--- a/tests/BccCode.Linq.Tests/Mockups/ApiClientMockupBase.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiClientMockupBase.cs
@@ -14,8 +14,11 @@ public class ApiClientMockupBase : IQueryableApiClient
 {
     private readonly Dictionary<Type, IList> _inMemoryData = new();
 
-    public string? LastEndpoint { get; set; }
-    public IQueryableParameters? LastRequestQuery { get; set; }
+    public string? PageEndpoint { get; set; }
+    public IQueryableParameters? ClientQuery { get; set; }
+    public IQueryableParameters? PageQuery { get; set; }
+
+    public int? QueryBatchSize => 100;
 
     public void RegisterData(Type type, IEnumerable enumerable)
     {
@@ -36,8 +39,8 @@ public class ApiClientMockupBase : IQueryableApiClient
     public TResult? Query<TResult>(string endpoint, IQueryableParameters query)
         where TResult : class
     {
-        LastEndpoint = endpoint;
-        LastRequestQuery = query;
+        PageEndpoint = PageEndpoint ?? endpoint;
+        PageQuery = query;
 
         var resultType = typeof(TResult);
 
@@ -63,8 +66,8 @@ public class ApiClientMockupBase : IQueryableApiClient
     public Task<TResult?> QueryAsync<TResult>(string endpoint, IQueryableParameters request, CancellationToken cancellationToken = default)
         where TResult : class
     {
-        LastEndpoint = endpoint;
-        LastRequestQuery = request;
+        PageEndpoint = endpoint;
+        PageQuery = request;
 
         return Task.FromResult(
             Query<TResult>(endpoint, request)

--- a/tests/BccCode.Linq.Tests/Mockups/ApiRequest.cs
+++ b/tests/BccCode.Linq.Tests/Mockups/ApiRequest.cs
@@ -29,4 +29,6 @@ internal class ApiRequest : IQueryableParameters
     public string? Alias { get; set; }
     [FromQuery(Name = "meta")]
     public string? Meta { get; set; }
+
+    public IQueryableParameters Clone() => (ApiRequest)MemberwiseClone();
 }

--- a/tests/BccCode.Linq.Tests/QueryablePagedEnumerableStateTests.cs
+++ b/tests/BccCode.Linq.Tests/QueryablePagedEnumerableStateTests.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BccCode.Linq.ApiClient;
+
+namespace RuleToLinqParser.Tests;
+
+public class QueryablePagedEnumerableStateTests
+{
+    const int BATCH_SIZE = 50;
+
+    [Fact]
+    public void PageWithOffsetAndLimit()
+    {
+        //Assemble
+        var clientParams = new QueryableParameters
+        {
+            Offset = 100,
+            Limit = 2000,
+            Page = 0
+        };
+        var state = QueryablePagedEnumerableState.Create(clientParams, BATCH_SIZE);
+
+        // Default 1st iteration
+        Assert.Equal(clientParams.Offset, state.PageParameters.Offset);
+        Assert.Equal(BATCH_SIZE, state.PageParameters.Limit);
+        Assert.Equal(BATCH_SIZE, state.PageSize);
+        Assert.False(state.Unlimited);
+        Assert.Equal(clientParams.Limit, state.TotalLimit);
+        Assert.Equal(0, state.TotalRequested);
+        Assert.Null(state.PageParameters.Page);
+
+        var expectedIterations = clientParams.Limit / BATCH_SIZE;
+        for (int i = 1; i <= expectedIterations; i++)
+        {
+            var morePages = state.NextPage(BATCH_SIZE);
+            Assert.Equal(i != expectedIterations, morePages);
+            if (morePages)
+            {
+                Assert.Equal(clientParams.Offset + i * BATCH_SIZE, state.PageParameters.Offset);
+                Assert.Equal(BATCH_SIZE, state.PageParameters.Limit);
+                Assert.Equal(BATCH_SIZE, state.PageSize);
+            }
+            Assert.False(state.Unlimited);
+            Assert.Equal(clientParams.Limit, state.TotalLimit);
+            Assert.Equal(i * BATCH_SIZE, state.TotalRequested);
+            Assert.Null(state.PageParameters.Page);
+
+        }
+        Assert.Equal(clientParams.Limit, state.TotalRequested);
+    }
+
+    [Fact]
+    public void PageWithLimitLessThanQueryBatchSize()
+    {
+        //Assemble
+        var clientParams = new QueryableParameters
+        {
+            Offset = 10,
+            Limit = 25,
+            Page = 0
+        };
+        var state = QueryablePagedEnumerableState.Create(clientParams, BATCH_SIZE);
+
+        Assert.Equal(clientParams.Offset, state.PageParameters.Offset);
+        Assert.Equal(clientParams.Limit, state.PageParameters.Limit);
+        Assert.Equal(clientParams.Limit, state.PageSize);
+        Assert.False(state.Unlimited);
+        Assert.Equal(clientParams.Limit, state.TotalLimit);
+        Assert.Equal(0, state.TotalRequested);
+        Assert.Null(state.PageParameters.Page);
+
+        Assert.False(state.NextPage(state.PageSize));
+        Assert.Equal(state.TotalRequested, clientParams.Limit);
+    }
+
+    [Fact]
+    public void PageWithLimitNotMultipleOfBatchSize()
+    {
+        //Assemble
+        var clientParams = new QueryableParameters
+        {
+            Offset = 5,
+            Limit = 75
+        };
+        var state = QueryablePagedEnumerableState.Create(clientParams, BATCH_SIZE);
+
+        // 1st iteration
+        Assert.Equal(clientParams.Offset, state.PageParameters.Offset);
+        Assert.Equal(BATCH_SIZE, state.PageParameters.Limit);
+        Assert.Equal(BATCH_SIZE, state.PageSize);
+        Assert.Equal(clientParams.Offset, state.PageParameters.Offset);
+        Assert.False(state.Unlimited);
+        Assert.Equal(clientParams.Limit, state.TotalLimit);
+        Assert.Equal(0, state.TotalRequested);
+        Assert.Null(state.PageParameters.Page);
+
+        // 2nd iteration
+        Assert.True(state.NextPage(state.PageSize));
+        Assert.Equal(clientParams.Limit % BATCH_SIZE, state.PageParameters.Limit);
+        Assert.Equal(state.PageParameters.Limit, state.PageSize);
+        Assert.Equal(clientParams.Offset + BATCH_SIZE, state.PageParameters.Offset);
+        Assert.False(state.Unlimited);
+        Assert.Equal(clientParams.Limit, state.TotalLimit);
+        Assert.Equal(BATCH_SIZE, state.TotalRequested);
+
+        //3rd iteration
+        Assert.False(state.NextPage(state.PageSize));
+        Assert.Equal(clientParams.Limit, state.TotalRequested);
+
+
+    }
+
+
+    [Fact]
+    public void PageWithPageInsteadOfOffset()
+    {
+        //Assemble
+        var clientParams = new QueryableParameters
+        {
+            Page = 3,
+            Limit = 75
+        };
+        var state = QueryablePagedEnumerableState.Create(clientParams, BATCH_SIZE);
+
+        // 1st iteration
+        Assert.Equal(clientParams.Limit * (clientParams.Page - 1), state.PageParameters.Offset);
+        Assert.Equal(clientParams.Limit * (clientParams.Page - 1), state.InitialOffset);
+        Assert.Equal(BATCH_SIZE, state.PageParameters.Limit);
+        Assert.Equal(BATCH_SIZE, state.PageSize);
+        Assert.Equal(clientParams.Limit, state.TotalLimit);
+        Assert.False(state.Unlimited);
+        Assert.Equal(0, state.TotalRequested);
+        Assert.Null(state.PageParameters.Page);
+
+        // 2nd iteration
+        Assert.True(state.NextPage(state.PageSize));
+        Assert.Equal(clientParams.Limit * (clientParams.Page - 1) + BATCH_SIZE, state.PageParameters.Offset);
+        Assert.Equal(clientParams.Limit * (clientParams.Page - 1), state.InitialOffset);
+        Assert.Equal(state.TotalLimit % BATCH_SIZE, state.PageParameters.Limit);
+        Assert.Equal(state.TotalLimit % BATCH_SIZE, state.PageSize);
+        Assert.Equal(clientParams.Limit, state.TotalLimit);
+        Assert.False(state.Unlimited);
+        Assert.Equal(BATCH_SIZE, state.TotalRequested);
+        Assert.Null(state.PageParameters.Page);
+
+        //3rd iteration
+        Assert.False(state.NextPage(state.PageSize));
+        Assert.Equal(clientParams.Limit, state.TotalRequested);
+    }
+
+    [Fact]
+    public void PageWithLimitAndNoMoreServerResults()
+    {
+        //Assemble
+        var clientParams = new QueryableParameters
+        {
+            Offset = 0,
+            Limit = 500
+        };
+        var state = QueryablePagedEnumerableState.Create(clientParams, BATCH_SIZE);
+
+        Assert.False(state.Unlimited);
+        Assert.True(state.NextPage(BATCH_SIZE));
+        Assert.True(state.NextPage(BATCH_SIZE));
+        Assert.False(state.NextPage(BATCH_SIZE-1));
+
+    }
+
+    [Fact]
+    public void PageWithoutLimitNoMoreServerResults()
+    {
+        //Assemble
+        var clientParams = new QueryableParameters
+        {
+            Offset = 10
+        };
+        var state = QueryablePagedEnumerableState.Create(clientParams, BATCH_SIZE);
+
+        Assert.True(state.Unlimited);
+        Assert.True(state.NextPage(BATCH_SIZE));
+        Assert.True(state.NextPage(BATCH_SIZE));
+        Assert.False(state.NextPage(BATCH_SIZE - 1));
+    }
+}
+


### PR DESCRIPTION
- Allow client to limit total number of rows retrieved using Limit

- Use offset and limit for API requests instead of page.

- Optimize page size to take initial limit into account

- Use concrete instead of abstract types for API requests (since it is not possible to deserialize to an interface)


