### PR TITLE
Removed .ToUniversalTime() from datetime and datetimeoffset conversions

### DIFF
--- a/src/BccCode.Linq/Client/QueryProvider/ApiQueryProvider.cs
+++ b/src/BccCode.Linq/Client/QueryProvider/ApiQueryProvider.cs
@@ -1577,7 +1577,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
         {
             stringBuilder.Append("\"");
 #pragma warning disable CS8605
-            DateTime valueDateTime = ((DateTime)value).ToUniversalTime();
+            DateTime valueDateTime = ((DateTime)value);
 #pragma warning restore CS8605
             if (valueDateTime != valueDateTime.Date)
             {
@@ -1593,7 +1593,7 @@ internal class ApiQueryProvider : ExpressionVisitor, IQueryProvider, IAsyncQuery
         {
             stringBuilder.Append("\"");
 #pragma warning disable CS8605
-            stringBuilder.Append(((DateTimeOffset)value).ToUniversalTime().ToString("O", CultureInfo.InvariantCulture));
+            stringBuilder.Append(((DateTimeOffset)value).ToString("O", CultureInfo.InvariantCulture));
 #pragma warning restore CS8605
             stringBuilder.Append("\"");
         }


### PR DESCRIPTION
Removed .ToUniversalTime() from:

1. DateTime conversion. The reasoning here is that DateTime generally represents a date, or a date and time which is independent of timezone. By changing the type to universal, we are adding time offsets that weren't necessarily intended (e.g. moving a birthdate to the previous day).

2.DateTimeOffset conversion. No need to change these to universal time, which would remove information about timezone, without actually changing anything about point in time that is indicated. Sometimes its useful to know what timezone a date/time is for, and not just which absolute point in time - so conversion to universal time is unnecessarily stripping additional information.