### PR TITLE
Feature/add numeric enum support

### DIFF
--- a/tests/BccCode.Linq.Tests/ApiClient/ResultListSerializationTest.cs
+++ b/tests/BccCode.Linq.Tests/ApiClient/ResultListSerializationTest.cs
@@ -32,7 +32,7 @@ public class ResultListSerializationTest
 
         var jsonString = JsonConvert.SerializeObject(resultList);
 
-        Assert.Equal(@"{""data"":[{""Name"":""Chuck Norris"",""Age"":0,""Country"":""US"",""CarHistory"":null,""Car"":{""Manufacturer"":""Opel"",""Model"":""Astra"",""YearOfProduction"":2003,""ManufacturerInfo"":null},""AnyDate"":""1940-03-10T00:00:00""}],""meta"":{""total"":1}}", jsonString);
+        Assert.Equal(@"{""data"":[{""Name"":""Chuck Norris"",""Age"":0,""Country"":""US"",""CarHistory"":null,""Car"":{""Manufacturer"":""Opel"",""Model"":""Astra"",""YearOfProduction"":2003,""ManufacturerInfo"":null},""AnyDate"":""1940-03-10T00:00:00"",""Type"":0}],""meta"":{""total"":1}}", jsonString);
     }
     
     [Fact]
@@ -57,7 +57,7 @@ public class ResultListSerializationTest
 
         var jsonString = JsonConvert.SerializeObject(resultList);
 
-        Assert.Equal(@"{""data"":[{""Name"":""Chuck Norris"",""Age"":0,""Country"":""US"",""CarHistory"":null,""Car"":{""Manufacturer"":""Opel"",""Model"":""Astra"",""YearOfProduction"":2003,""ManufacturerInfo"":null},""AnyDate"":""1940-03-10T00:00:00""}]}", jsonString);
+        Assert.Equal(@"{""data"":[{""Name"":""Chuck Norris"",""Age"":0,""Country"":""US"",""CarHistory"":null,""Car"":{""Manufacturer"":""Opel"",""Model"":""Astra"",""YearOfProduction"":2003,""ManufacturerInfo"":null},""AnyDate"":""1940-03-10T00:00:00"",""Type"":0}]}", jsonString);
     }
     
     [Fact]

--- a/tests/BccCode.Linq.Tests/FilterTests.cs
+++ b/tests/BccCode.Linq.Tests/FilterTests.cs
@@ -169,4 +169,7 @@ public class FilterTests
             var value = ((Filter<DateTime>)filter.Properties["AnyDate"]).Properties["_eq"];
         });
     }
+
+
+
 }

--- a/tests/BccCode.Linq.Tests/Helpers/Person.cs
+++ b/tests/BccCode.Linq.Tests/Helpers/Person.cs
@@ -15,6 +15,8 @@ public class Person
     public Car Car { get; set; } = new("Opel", "Astra", 2003);
     public DateTime AnyDate { get; set; }
 
+    public PersonType Type {  get; set; }
+
     public Person(string name, int age, string country, DateTime anyDate)
     {
         Name = name;
@@ -22,6 +24,14 @@ public class Person
         Country = country;
         AnyDate = anyDate;
     }
+}
+
+public enum PersonType
+{
+    Unknown = 0,
+    Customer = 1,
+    Staff = 2,
+    Partner = 3
 }
 
 public class Car

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
 using BccCode.Linq.Client;
+using BccCode.Linq.Tests.Helpers;
 
 namespace BccCode.Linq.Tests;
 
@@ -594,13 +595,57 @@ public class LinqQueryProviderTests
         Assert.Equal(2, api.ClientQuery?.Limit);
         Assert.Null(testClass);
     }
-    
+
     #endregion
-    
+
+    #region Enums
+
+    [Fact]
+    public void NumericEnumTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Persons.Where(t => t.Type == PersonType.Staff);
+
+        var persons = query.ToList();
+
+        Assert.Equal("{\"type\": {\"_eq\": 2}}", api.ClientQuery?.Filter);
+
+    }
+
+    [Fact]
+    public void StringEnumTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Persons.Where(t => t.Type.ToString() == PersonType.Staff.ToString());
+
+        var persons = query.ToList();
+
+        Assert.Equal("{\"type\": {\"_eq\": \"Staff\"}}", api.ClientQuery?.Filter);
+
+    }
+
+
+    [Fact(Skip = "This approach does not work.")]
+    public void StringEnumAltTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Persons.Where(t => t.Type.ToString().Equals(PersonType.Staff));
+
+        var persons = query.ToList();
+
+        Assert.Equal("{\"type\": {\"_eq\": \"Staff\"}}", api.ClientQuery?.Filter);
+
+    }
+
+    #endregion
+
     #region Where
 
     #region Where property equal to ...
-    
+
     [Fact]
     public void WhereGuidEqualStaticNewTest()
     {
@@ -2202,4 +2247,6 @@ public class LinqQueryProviderTests
     }
 
     #endregion
+
+
 }


### PR DESCRIPTION
Adds support for queries like this:
![image](https://github.com/bcc-code/bcc-linq/assets/1876625/5111eb4f-cac9-436e-b7d1-91f9197bbcfb)

This is slightly controversial because the query will interpret the enum as an integer, not a string. This will work well for enums that are defined as integers on the server side, but not if the enum is only represented as a string on the server.
