### PR TITLE
support custom property names via attributes

### DIFF
--- a/tests/BccCode.Linq.Tests/Helpers/TestClass.cs
+++ b/tests/BccCode.Linq.Tests/Helpers/TestClass.cs
@@ -1,4 +1,8 @@
-﻿namespace BccCode.Linq.Tests.Helpers;
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
+namespace BccCode.Linq.Tests.Helpers;
 
 public class TestClass
 {
@@ -20,6 +24,15 @@ public class TestClass
 #if NET6_0_OR_GREATER
     public DateOnly DateOnly { get; set; }
 #endif
+    
+    [DataMember(Name = "custom_name")]
+    public NestedClass CustomNameByDataMemberAttribute { get; set; }
+    
+    [JsonPropertyName("custom_name")]
+    public NestedClass CustomNameByJsonPropertyNameAttribute { get; set; }
+    
+    [JsonProperty("custom_name")]
+    public NestedClass CustomNameByNewtonsoftJsonPropertyAttribute { get; set; }
 }
 
 public class NestedClass

--- a/tests/BccCode.Linq.Tests/LinqTests.cs
+++ b/tests/BccCode.Linq.Tests/LinqTests.cs
@@ -2285,6 +2285,60 @@ public class LinqQueryProviderTests
         Assert.Equal(5, persons.Count);
     }
 
+    [Fact]
+    public void IncludeCustomNameByDataMemberAttributeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Empty
+            .Include(p => p.CustomNameByDataMemberAttribute);
+
+        var emptyList = query.ToList();
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*,custom_name.*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
+        Assert.Empty(emptyList);
+    }
+    
+    [Fact]
+    public void IncludeCustomNameByJsonPropertyNameAttributeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Empty
+            .Include(p => p.CustomNameByJsonPropertyNameAttribute);
+
+        var emptyList = query.ToList();
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*,custom_name.*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
+        Assert.Empty(emptyList);
+    }
+    
+    [Fact]
+    public void IncludeCustomNameByNewtonsoftJsonPropertyAttributeTest()
+    {
+        var api = new ApiClientMockup();
+
+        var query = api.Empty
+            .Include(p => p.CustomNameByNewtonsoftJsonPropertyAttribute);
+
+        var emptyList = query.ToList();
+        Assert.Equal("empty", api.PageEndpoint);
+        Assert.Null(api.ClientQuery?.Filter);
+        Assert.Equal("*,custom_name.*", api.ClientQuery?.Fields);
+        Assert.Null(api.ClientQuery?.Sort);
+        Assert.Null(api.ClientQuery?.Offset);
+        Assert.Null(api.ClientQuery?.Limit);
+        Assert.Empty(emptyList);
+    }
+
     #endregion
 
 


### PR DESCRIPTION
resolves #72

This allows the definition of custom property names with the following attributes (in that order)

- `[DataMember(Name = "...")]` from `System.Runtime.Serialization`
- `[JsonPropertyName("")]` from `System.Text.Json.Serialization` (supported from .NET 6.0)
- `[JsonProperty("")]` from `Newtonsoft.Json` (requires Nuget package)
