### PR TITLE
fix server query parameter 'sort'

### DIFF
--- a/tests/BccCode.Linq.Tests/Server/ApplyApiRequestTests.cs
+++ b/tests/BccCode.Linq.Tests/Server/ApplyApiRequestTests.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel;
+using System.Reflection;
+using BccCode.Linq.Server;
+using BccCode.Linq.Tests.Helpers;
+
+namespace BccCode.Linq.Tests.Server;
+
+public class ApplyApiRequestTests
+{
+    [Fact]
+    public void TestGetSortingFromRequest()
+    {
+        var structuredSorting = CollectionsExtensions.GetSorting<TestClass>($"-{nameof(TestClass.AnyDate)},{nameof(TestClass.Uuid)}").ToList();
+        var expectedStructSorting = new List<(PropertyInfo?, ListSortDirection Descending)>
+        {
+            (typeof(TestClass).GetProperty(nameof(TestClass.AnyDate)), ListSortDirection.Descending),
+            (typeof(TestClass).GetProperty(nameof(TestClass.Uuid)), ListSortDirection.Ascending),
+        };
+
+        Assert.NotNull(structuredSorting);
+        Assert.NotNull(expectedStructSorting);
+        Assert.Equal(expectedStructSorting, structuredSorting);
+    }
+}

--- a/tests/BccCode.Linq.Tests/Server/FilterToLambdaParserTests.cs
+++ b/tests/BccCode.Linq.Tests/Server/FilterToLambdaParserTests.cs
@@ -1,7 +1,7 @@
 ﻿using BccCode.Linq.Server;
 using BccCode.Linq.Tests.Helpers;
 
-namespace BccCode.Linq.Tests;
+namespace BccCode.Linq.Tests.Server;
 
 public class FilterToLambdaParserTests
 {

--- a/tests/BccCode.Linq.Tests/Server/InvertFilterTests.cs
+++ b/tests/BccCode.Linq.Tests/Server/InvertFilterTests.cs
@@ -1,7 +1,7 @@
 ﻿using BccCode.Linq.Server;
 using BccCode.Linq.Tests.Helpers;
 
-namespace BccCode.Linq.Tests;
+namespace BccCode.Linq.Tests.Server;
 
 public class InvertFilterTests
 {


### PR DESCRIPTION
The sort parameter has a bug which always throws an `InvalidOperationException` when used. This PR fixes the bug and adds a unit test for it.

This fixes the issue in https://github.com/bcc-code/bcc-contributions-api/pull/131#issuecomment-1981773432