### PR TITLE
fix default sorting + add ApplyApiRequest XML documentation

### DIFF
--- a/src/BccCode.Linq/Server/CollectionsExtensions.cs
+++ b/src/BccCode.Linq/Server/CollectionsExtensions.cs
@@ -101,7 +101,33 @@ public static class CollectionsExtensions
             yield return (propertyInfo, sortDirection);
         }
     }
-
+    
+    /// <summary>
+    /// Applies query parameters to a <seealso cref="IQueryable"/> object.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The entity type.
+    /// </typeparam>
+    /// <param name="source">
+    /// The <seealso cref="IQueryable"/> object the query parameters shall be applied to.
+    /// </param>
+    /// <param name="query">
+    /// The query parameters which shall be applied.
+    /// </param>
+    /// <param name="defaultSort">
+    /// Optional. A default sorting which is applied when no sorting is applied via the query parameters (<paramref name="query"/>).
+    /// </param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Is thrown when:
+    /// - <see cref="IQueryableParameters.Offset"/> is below zero.
+    /// - <see cref="IQueryableParameters.Page"/> is below 1.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Is thrown when:
+    /// - <see cref="IQueryableParameters.Offset"/> and <see cref="IQueryableParameters.Page"/> is used at the same time.
+    /// - <see cref="IQueryableParameters.Page"/> is used and <see cref="IQueryableParameters.Limit"/> is not given.
+    /// </exception>
     public static IQueryable<T> ApplyApiRequest<T>(this IQueryable<T> source, IQueryableParameters query,
         string? defaultSort = null)
         where T : class
@@ -137,8 +163,9 @@ public static class CollectionsExtensions
 
                     orderedSource = (IOrderedQueryable<T>)source.Provider.CreateQuery(
                         Expression.Call(
-                            source.Expression,
+                            null,
                             method,
+                            source.Expression,
                             keySelector
                         ));
                 }
@@ -153,8 +180,9 @@ public static class CollectionsExtensions
 
                     orderedSource = (IOrderedQueryable<T>)orderedSource.Provider.CreateQuery(
                         Expression.Call(
-                            orderedSource.Expression,
+                            null,
                             method,
+                            orderedSource.Expression,
                             keySelector
                         ));
                 }

--- a/tests/BccCode.Linq.Tests/Server/ApplyApiRequestTests.cs
+++ b/tests/BccCode.Linq.Tests/Server/ApplyApiRequestTests.cs
@@ -2,11 +2,19 @@
 using System.Reflection;
 using BccCode.Linq.Server;
 using BccCode.Linq.Tests.Helpers;
+using BccCode.Platform;
 
 namespace BccCode.Linq.Tests.Server;
 
+/// <summary>
+/// A test class holding tests for the <see cref="CollectionsExtensions.ApplyApiRequest"/> static method.
+/// </summary>
 public class ApplyApiRequestTests
 {
+    /// <summary>
+    /// Tests if the <see cref="CollectionsExtensions.GetSorting"/> method parses the
+    /// sorting string correctly.
+    /// </summary>
     [Fact]
     public void TestGetSortingFromRequest()
     {
@@ -20,5 +28,45 @@ public class ApplyApiRequestTests
         Assert.NotNull(structuredSorting);
         Assert.NotNull(expectedStructSorting);
         Assert.Equal(expectedStructSorting, structuredSorting);
+    }
+
+    /// <summary>
+    /// Tests if the default sorting is used.
+    /// </summary>
+    [Fact]
+    public void TestUseDefaultSorting()
+    {
+        var personsQueryable = Seeds.Persons.AsQueryable();
+
+        var result = personsQueryable
+            .ApplyApiRequest(new QueryableParameters(), defaultSort: $"{nameof(Person.Age)}")
+            .ToList();
+        var expectedResult = personsQueryable
+            .OrderBy(p => p.Age)
+            .ToList();
+
+        Assert.Equal(expectedResult, result);
+    }
+
+    /// <summary>
+    /// Tests if a custom sorting applied via the <see cref="QueryableParameters"/>
+    /// overwrites the default sorting passed to the <see cref="CollectionsExtensions.ApplyApiRequest"/> method.
+    /// </summary>
+    [Fact]
+    public void TestUseCustomSortingOverDefaultSorting()
+    {
+        var personsQueryable = Seeds.Persons.AsQueryable();
+
+        var result = personsQueryable
+            .ApplyApiRequest(new QueryableParameters
+                {
+                    Sort = $"-{nameof(Person.Age)}"
+                }, defaultSort: $"{nameof(Person.Age)}")
+            .ToList();
+        var expectedResult = personsQueryable
+            .OrderByDescending(p => p.Age)
+            .ToList();
+
+        Assert.Equal(expectedResult, result);
     }
 }


### PR DESCRIPTION
This should fix the soring issue in https://github.com/bcc-code/bcc-contributions-api/pull/131.

In addition, it adds XML comment for the `ApplyApiRequest` method. See https://github.com/bcc-code/bcc-linq/issues/81.