### PR TITLE
use case insensitive properties for search on server side

### DIFF
--- a/src/BccCode.Linq/Server/CollectionsExtensions.cs
+++ b/src/BccCode.Linq/Server/CollectionsExtensions.cs
@@ -41,6 +41,9 @@ public static class CollectionsExtensions
     internal static IEnumerable<(PropertyInfo, ListSortDirection)> GetSorting<T>(string sort)
         where T : class
     {
+        var propertyMetadata = typeof(T)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
+
         foreach (var sortByField in sort.Split(','))
         {
             if (sortByField.Contains('.'))
@@ -71,8 +74,10 @@ public static class CollectionsExtensions
             }
 
             // try find property by camel case
-            var propertyInfo = typeof(T).GetProperty(propertyName,
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
+            //var propertyInfo = typeof(T).GetProperty(propertyName,
+            //    BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
+            // try find case insensitive property by name
+            var propertyInfo = propertyMetadata.FirstOrDefault(x => string.Equals(x.Name, propertyName, StringComparison.CurrentCultureIgnoreCase));
 
             if (propertyInfo == null)
             {
@@ -101,7 +106,7 @@ public static class CollectionsExtensions
             yield return (propertyInfo, sortDirection);
         }
     }
-    
+
     /// <summary>
     /// Applies query parameters to a <seealso cref="IQueryable"/> object.
     /// </summary>

--- a/src/BccCode.Linq/Server/CollectionsExtensions.cs
+++ b/src/BccCode.Linq/Server/CollectionsExtensions.cs
@@ -41,9 +41,6 @@ public static class CollectionsExtensions
     internal static IEnumerable<(PropertyInfo, ListSortDirection)> GetSorting<T>(string sort)
         where T : class
     {
-        var propertyMetadata = typeof(T)
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
-
         foreach (var sortByField in sort.Split(','))
         {
             if (sortByField.Contains('.'))
@@ -73,11 +70,9 @@ public static class CollectionsExtensions
                 sortDirection = ListSortDirection.Ascending;
             }
 
-            // try find property by camel case
-            //var propertyInfo = typeof(T).GetProperty(propertyName,
-            //    BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
-            // try find case insensitive property by name
-            var propertyInfo = propertyMetadata.FirstOrDefault(x => string.Equals(x.Name, propertyName, StringComparison.CurrentCultureIgnoreCase));
+            // try find property
+            var propertyInfo = typeof(T).GetProperty(propertyName,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.IgnoreCase);
 
             if (propertyInfo == null)
             {

--- a/src/BccCode.Linq/Server/Filter.cs
+++ b/src/BccCode.Linq/Server/Filter.cs
@@ -7,6 +7,7 @@ using BccCode;
 using BccCode.Linq;
 using BccCode.Linq.Server;
 */
+using System.Reflection;
 using BccCode.Linq.Extensions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -87,11 +88,12 @@ public class Filter<T> : Filter
     {
         var deserializedJson = FilterDeserializationHelpers.DeserializeJsonRule(json);
 
-        var propertyMetadata = typeof(T).GetProperties();
+        var propertyMetadata = typeof(T)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
 
         foreach (var (key, value) in deserializedJson)
         {
-            var propertyInfo = propertyMetadata.FirstOrDefault(x => x.Name.ToLower() == key.ToLower());
+            var propertyInfo = propertyMetadata.FirstOrDefault(x => string.Equals(x.Name, key, StringComparison.CurrentCultureIgnoreCase));
 
             if (new[] { "_and", "_or" }.Contains(key))
             {

--- a/src/BccCode.Linq/Server/Filter.cs
+++ b/src/BccCode.Linq/Server/Filter.cs
@@ -88,12 +88,10 @@ public class Filter<T> : Filter
     {
         var deserializedJson = FilterDeserializationHelpers.DeserializeJsonRule(json);
 
-        var propertyMetadata = typeof(T)
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty);
-
         foreach (var (key, value) in deserializedJson)
         {
-            var propertyInfo = propertyMetadata.FirstOrDefault(x => string.Equals(x.Name, key, StringComparison.CurrentCultureIgnoreCase));
+            var propertyInfo = typeof(T).GetProperty(key,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.IgnoreCase);
 
             if (new[] { "_and", "_or" }.Contains(key))
             {


### PR DESCRIPTION
Currently the case (upper/lower case) is ignored for properties on server side for filters, but not on search properties. This PR fixes this.

This is an issue, because BccCode.Linq client converts the naming to camel case, but there is no conversion back to pascal case again.